### PR TITLE
290 Remove the link to the webapp "homepage" in the Fractal logo

### DIFF
--- a/src/components/ui/Header/index.tsx
+++ b/src/components/ui/Header/index.tsx
@@ -1,13 +1,28 @@
-import { Link } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { Link, useMatch } from "react-router-dom";
 import FractalLogo from "../svg/Logo";
 import HeaderMenu from "./HeaderMenu";
 
 function Header() {
+  const daoHomeMatch = useMatch("/daos/:id/*");
+  const [daoHome, setDaoHome] = useState("/");
+  const [validatedAddress, setValidatedAddress] = useState<string>();
+  
+  useEffect(() => {
+    if (daoHomeMatch) {
+      setDaoHome(daoHomeMatch.pathnameBase);
+      setValidatedAddress(daoHomeMatch.params.id);
+    } else {
+      setDaoHome("/");
+      setValidatedAddress(undefined);
+    }
+  }, [daoHomeMatch]);
+
   return (
     <header className="py-4 bg-gray-600">
       <div className="container flex justify-between items-center">
         <div className="mr-4">
-          <Link to="/">
+          <Link to={daoHome} state={{ validatedAddress }}>
             <FractalLogo />
           </Link>
         </div>

--- a/src/components/ui/Header/index.tsx
+++ b/src/components/ui/Header/index.tsx
@@ -1,22 +1,24 @@
 import { useState, useEffect } from "react";
 import { Link, useMatch } from "react-router-dom";
+import { useDAOData } from "../../../contexts/daoData";
 import FractalLogo from "../svg/Logo";
 import HeaderMenu from "./HeaderMenu";
 
 function Header() {
-  const daoHomeMatch = useMatch("/daos/:id/*");
+  const [{ daoAddress }] = useDAOData();
+  const daoHomeMatch = useMatch("/daos/:address/*");
   const [daoHome, setDaoHome] = useState("/");
   const [validatedAddress, setValidatedAddress] = useState<string>();
   
   useEffect(() => {
-    if (daoHomeMatch) {
+    if (daoHomeMatch && daoAddress) {
       setDaoHome(daoHomeMatch.pathnameBase);
-      setValidatedAddress(daoHomeMatch.params.id);
+      setValidatedAddress(daoHomeMatch.params.address);
     } else {
       setDaoHome("/");
       setValidatedAddress(undefined);
     }
-  }, [daoHomeMatch]);
+  }, [daoHomeMatch, daoAddress]);
 
   return (
     <header className="py-4 bg-gray-600">


### PR DESCRIPTION
Closes #290

When anywhere in a DAO, the logo in header will go back to the DAO's home page.

When not loaded in a DAO, the logo will go back to the actual webapp's home page.