### PR TITLE
Remove the rpc error callback from useTransaction hook

### DIFF
--- a/src/contexts/web3Data/transactions.ts
+++ b/src/contexts/web3Data/transactions.ts
@@ -16,7 +16,6 @@ interface ContractCallParams {
   failedCallback?: () => void;
   successCallback?: (txReceipt: ContractReceipt) => void;
   completedCallback?: () => void;
-  rpcErrorCallback?: (reason: string) => void;
 }
 
 const useTransaction = () => {
@@ -74,29 +73,11 @@ const useTransaction = () => {
           return;
         }
 
-        if (params.rpcErrorCallback) {
-          let msg = (error.data?.message ?? "No reason") as string;
-
-          if (msg.includes('reason string')) {
-            msg = msg.split('reason string')[1];
-          }
-
-          params.rpcErrorCallback(_formatContractError(msg));
-        } else {
-          toast.error("There was an error! Check your browser's console logs for more details.");
-        }
+        toast.error("There was an error! Check your browser's console logs for more details.");
       });
   }, []);
 
   return [contractCall, pending] as const;
-}
-
-function _formatContractError(error: string) {
-  if (error.includes('not the owner')) { // surely there's a better way to do this... right? T_T
-    return "Only the contract owner can do this";
-  }
-
-  return error;
 }
 
 export { useTransaction };

--- a/src/hooks/useCastVote.ts
+++ b/src/hooks/useCastVote.ts
@@ -41,9 +41,6 @@ const useCastVote = ({
       pendingMessage: "Casting Vote",
       failedMessage: "Vote Cast Failed",
       successMessage: "Vote Casted",
-      rpcErrorCallback: (error: any) => {
-        console.error(error)
-      },
     });
   }, [contractCallCastVote, daoData.moduleAddresses, proposalId, signerOrProvider, vote])
   return castVote;

--- a/src/hooks/useCreateProposal.ts
+++ b/src/hooks/useCreateProposal.ts
@@ -57,9 +57,6 @@ const useCreateProposal = ({
         clearState();
         navigate(`/daos/${daoAddress}`,);
       },
-      rpcErrorCallback: (error: any) => {
-        console.error(error)
-      },
     });
   }, [daoAddress, navigate, contractCallCreateProposal, daoData, proposalData, setPending, signerOrProvider, clearState])
   return createProposal;

--- a/src/hooks/useDeployDAO.ts
+++ b/src/hooks/useDeployDAO.ts
@@ -213,9 +213,6 @@ const useDeployDAO = ({
           navigate(`/daos/${daoAddress}`);
         }
       },
-      rpcErrorCallback: (error: any) => {
-        console.error(error);
-      },
     });
   }, [
     signerOrProvider,

--- a/src/hooks/useExecuteTransaction.ts
+++ b/src/hooks/useExecuteTransaction.ts
@@ -40,9 +40,6 @@ const useExecuteTransaction = ({
       pendingMessage: "Executing Transaction",
       failedMessage: "Executing Failed",
       successMessage: "Executing Completed",
-      rpcErrorCallback: (error: any) => {
-        console.error(error)
-      },
     });
   }, [contractCallExecuteTransaction, daoData, proposalData, signerOrProvider])
   return executeTransaction;

--- a/src/hooks/useQueueTransaction.ts
+++ b/src/hooks/useQueueTransaction.ts
@@ -40,9 +40,6 @@ const useQueueTransaction = ({
       pendingMessage: "Queuing Transaction...",
       failedMessage: "Queuing Failed",
       successMessage: "Queuing Completed",
-      rpcErrorCallback: (error: any) => {
-        console.error(error)
-      },
     });
   }, [contractCallQueueTransaction, daoData, proposalData, signerOrProvider])
   return queueTransaction;


### PR DESCRIPTION
This was getting in the way of toast errors being displayed to the user.

We should be striving to never even allow users to attempt to make transactions that will fail. We can do that with smart logic (looking at on-chain data and comparing it with who the user is and what they're about to do) to enable/disable buttons that trigger transaction.

Seems like the primary use case for this functionality was to inform users of business logic (ur not the owner, can't do this), but again, that shouldn't be caught at the time of making a transaction, it should be caught before then.