### PR TITLE
cleans up padding on propsal action

### DIFF
--- a/src/components/Proposals/ProposalAction.tsx
+++ b/src/components/Proposals/ProposalAction.tsx
@@ -1,0 +1,25 @@
+import ContentBox from "../ui/ContentBox";
+import { PrimaryButton } from "../ui/forms/Button";
+
+interface ProposalActionProps {
+  label: string;
+  btnLabel: string;
+  pending: boolean;
+  actionFunc: (...args: any | undefined) => void;
+}
+
+export function ProposalAction({
+  actionFunc,
+  pending,
+  label,
+  btnLabel
+}: ProposalActionProps) {
+  return (
+    <ContentBox>
+    <div className="flex justify-between items-center">
+      <div className="text-gray-25">{label}</div>
+      <PrimaryButton label={btnLabel} className="mr-0" onClick={actionFunc} disabled={pending} />
+    </div>
+  </ContentBox>
+  )
+}

--- a/src/components/Proposals/ProposalExecute.tsx
+++ b/src/components/Proposals/ProposalExecute.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 import { ProposalData, ProposalState } from "../../contexts/daoData/useProposals";
 import useExecuteTransaction from "../../hooks/useExecuteTransaction";
-import { PrimaryButton } from "../ui/forms/Button";
 import { useBlockchainData } from "../../contexts/blockchainData";
+import { ProposalAction } from "./ProposalAction";
 
 function ProposalExecute({ proposal }: { proposal: ProposalData }) {
   const [show, setShow] = useState<boolean>(false);
@@ -27,19 +27,12 @@ function ProposalExecute({ proposal }: { proposal: ProposalData }) {
   if (!show) return null;
 
   return (
-    <div className="flex border-1 items-center m-2 bg-gray-600 py-2 rounded-md">
-      <div className="align-middle text-gray-25 mx-4">
-        Proposal ready for execution
-      </div>
-      <div className="flex flex-grow justify-end mx-4">
-        <PrimaryButton
-          onClick={() => executeTransaction()}
-          label="Execute"
-          disabled= {pending}
-        />
-      </div>
-    </div>
-  );
+    <ProposalAction 
+      btnLabel="Execute" 
+      label="Proposal ready for execution" 
+      actionFunc={executeTransaction} 
+      pending={pending} />
+  )
 }
 
 export default ProposalExecute;

--- a/src/components/Proposals/ProposalQueue.tsx
+++ b/src/components/Proposals/ProposalQueue.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { ProposalData, ProposalState } from "../../contexts/daoData/useProposals";
 import useQueueTransaction from "../../hooks/useQueueTransaction";
-import { PrimaryButton } from "../ui/forms/Button";
+import { ProposalAction } from "./ProposalAction";
 
 function ProposalQueue({ proposal }: { proposal: ProposalData }) {
   const [pending, setPending] = useState<boolean>(false);
@@ -16,13 +16,12 @@ function ProposalQueue({ proposal }: { proposal: ProposalData }) {
   }
 
   return (
-    <div className="flex border-1 items-center m-2 bg-gray-600 py-2 rounded-md">
-      <div className="align-middle text-gray-25 mx-4">Proposal has succeeded and ready to queue</div>
-      <div className="flex flex-grow justify-end mx-4">
-        <PrimaryButton label="Queue Proposal" onClick={queueTransaction} disabled= {pending} />
-      </div>
-    </div>
-  );
+    <ProposalAction
+      btnLabel="Queue Proposal"
+      label="Proposal has succeeded and ready to queue"
+      actionFunc={queueTransaction}
+      pending={pending} />
+  )
 }
 
 export default ProposalQueue;


### PR DESCRIPTION
## Overview
closes #280

- cleans up padding on proposal actions
- extracts UI of both components to separate component

## Notes

I did not see any designs any where for these buttons. So I updated them to use the `ContentBox`  component. Padding is now similar to rest of site for this section.

## Screenshots
![image](https://user-images.githubusercontent.com/38386583/172530002-692e5c9b-194d-489f-a1ae-03a8f47e6eac.png)

![image](https://user-images.githubusercontent.com/38386583/172530062-51ed941d-debb-411d-bc18-7ee471d3f93d.png)
