### PR TITLE
#281 automated state change active => succeeded/defeated

### DIFF
--- a/src/contexts/daoData/useProposals.ts
+++ b/src/contexts/daoData/useProposals.ts
@@ -584,6 +584,7 @@ const useProposalsWithoutUserData = (
   }, [governorModule]);
 
   // Check for pending proposals that have become active
+  // Check for Active proposals that have become defeated/Succeeded
   useEffect(() => {
     if (currentBlockNumber === undefined) {
       return;
@@ -599,6 +600,20 @@ const useProposalsWithoutUserData = (
           newProposal.startBlock.toNumber() <= currentBlockNumber
         ) {
           newProposal.state = ProposalState.Active;
+        } 
+        else if (
+          newProposal.state === ProposalState.Active &&
+          currentBlockNumber >= newProposal.endBlock.toNumber() &&
+          newProposal.forVotesCount!.lte(newProposal.againstVotesCount!)
+        ) {
+          newProposal.state = ProposalState.Defeated
+        }
+        else if (
+          newProposal.state === ProposalState.Active &&
+          currentBlockNumber >= newProposal.endBlock.toNumber() &&
+          newProposal.forVotesCount!.gt(newProposal.againstVotesCount!)
+        ) {
+          newProposal.state = ProposalState.Succeeded
         }
 
         return newProposal;


### PR DESCRIPTION
PR Updates
1. Added a condiition which checks if the state has changed from active => succeeded
2. Added a condition which checks if the state has changed form active => Defeated

Tests Include - without refreshing page
1. Checking state active => succeeded without when a vote passes
2. Checking state active => defeated when no vote is made
3. Checking state active => defeated when more against votes are made
4. Checking state active => defeated when only abstain votes are made
5. For both the proposal list and proposal details page