### PR TITLE
fixed prettier warnings

### DIFF
--- a/src/contexts/daoData/useProposals.ts
+++ b/src/contexts/daoData/useProposals.ts
@@ -587,18 +587,17 @@ const useProposalsWithoutUserData = (
           newProposal.startBlock.toNumber() <= currentBlockNumber
         ) {
           newProposal.state = ProposalState.Active;
-        } 
-          else if (
-            newProposal.state === ProposalState.Active &&
-            currentBlockNumber >= newProposal.endBlock.toNumber()
-          ) {
-            if (newProposal.forVotesCount!.lte(newProposal.againstVotesCount!)) {
-              newProposal.state = ProposalState.Defeated
-            }
-            if (newProposal.forVotesCount!.gt(newProposal.againstVotesCount!)) {
-              newProposal.state = ProposalState.Succeeded
-            }
+        } else if (
+          newProposal.state === ProposalState.Active &&
+          currentBlockNumber >= newProposal.endBlock.toNumber()
+        ) {
+          if (newProposal.forVotesCount!.lte(newProposal.againstVotesCount!)) {
+            newProposal.state = ProposalState.Defeated;
           }
+          if (newProposal.forVotesCount!.gt(newProposal.againstVotesCount!)) {
+            newProposal.state = ProposalState.Succeeded;
+          }
+        }
 
         return newProposal;
       });


### PR DESCRIPTION
## Overview

There were some prettier warnings 
![image](https://user-images.githubusercontent.com/38386583/172828128-e29a59c0-fd5c-4095-966b-24ce89a22ff7.png)


I think there is one more step with `eslint/prettier`. We may need to make sure that the IDEs are displaying the errors/warnings correctly (IDE might not be setup to look for the `eslint`. 

The other question this poses, should this throw an error? instead of showing up as an error?