### PR TITLE
Favorites

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -3,11 +3,8 @@ import useBreadcrumbs, { BreadcrumbMatch } from 'use-react-router-breadcrumbs';
 
 import { useDAOData } from '../contexts/daoData';
 import DetailsIcon from './ui/svg/Details';
-import Info from './ui/svg/Info';
 import RightArrow from './ui/svg/RightArrow';
 import TreasuryIcon from './ui/svg/Treasury';
-import TooltipAddressContent from './ui/TooltipAddressContent';
-import TooltipWrapper from './ui/TooltipWrapper';
 import Favorite from './ui/Favorite';
 
 function DAOName() {
@@ -63,47 +60,31 @@ function Breadcrumbs() {
     <div className="py-2 text-white bg-gray-600 bg-opacity-70 font-mono tracking-wider">
       <div className="container flex justify-between items-center">
         <div>
-          <TooltipWrapper
-            isVisible={breadcrumbs.length === 1}
-            content={
-              daoAddress && (
-                <TooltipAddressContent
-                  address={daoAddress}
-                  title="DAO address:"
-                />
-              )
-            }
-          >
-            <div className="flex">
-              {breadcrumbs.map(({ match, breadcrumb }, i) => (
-                <div
-                  key={match.pathname}
-                  className="flex"
-                >
-                  {match.pathname === location.pathname ? (
-                    <span>{breadcrumb}</span>
-                  ) : (
-                    <NavLink
-                      className="text-gold-500"
-                      to={match.pathname}
-                    >
-                      {breadcrumb}
-                    </NavLink>
-                  )}
-                  {i < breadcrumbs.length - 1 && (
-                    <div className="mx-1">
-                      <RightArrow />
-                    </div>
-                  )}
-                  {breadcrumbs.length === 1 && daoAddress && (
-                    <div className="ml-2">
-                      <Info />
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          </TooltipWrapper>
+          <div className="flex items-center">
+            <Favorite />
+            {breadcrumbs.map(({ match, breadcrumb }, i) => (
+              <div
+                key={match.pathname}
+                className="flex"
+              >
+                {match.pathname === location.pathname ? (
+                  <span>{breadcrumb}</span>
+                ) : (
+                  <NavLink
+                    className="text-gold-500"
+                    to={match.pathname}
+                  >
+                    {breadcrumb}
+                  </NavLink>
+                )}
+                {i < breadcrumbs.length - 1 && (
+                  <div className="mx-1">
+                    <RightArrow />
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
         </div>
         {breadcrumbs.length === 1 && daoAddress && (
           <div className="flex gap-4 sm:gap-2">
@@ -121,7 +102,6 @@ function Breadcrumbs() {
               <div className="text-sm font-semibold">Treasury</div>
               <TreasuryIcon />
             </NavLink>
-            <Favorite />
           </div>
         )}
       </div>

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -38,6 +38,10 @@ function Breadcrumbs() {
   excludePaths.push(daosNew);
   const matchDaosNew = useMatch(daosNew);
 
+  const daosFavorites = '/daos/favorites';
+  excludePaths.push(daosFavorites);
+  const matchDaosFavorites = useMatch(daosFavorites);
+
   const breadcrumbOptions = { excludePaths };
   const routes = [
     { path: '/daos/:address', breadcrumb: DAOName },
@@ -47,7 +51,9 @@ function Breadcrumbs() {
   ];
   const breadcrumbs = useBreadcrumbs(routes, breadcrumbOptions);
 
-  const anyExcludeMatch = [matchHome, matchDaos, matchDaosNew].some(match => match !== null);
+  const anyExcludeMatch = [matchHome, matchDaos, matchDaosNew, matchDaosFavorites].some(
+    match => match !== null
+  );
   if (anyExcludeMatch) {
     return <></>;
   }

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -8,6 +8,7 @@ import RightArrow from './ui/svg/RightArrow';
 import TreasuryIcon from './ui/svg/Treasury';
 import TooltipAddressContent from './ui/TooltipAddressContent';
 import TooltipWrapper from './ui/TooltipWrapper';
+import Favorite from './ui/Favorite';
 
 function DAOName() {
   const params = useParams();
@@ -120,6 +121,7 @@ function Breadcrumbs() {
               <div className="text-sm font-semibold">Treasury</div>
               <TreasuryIcon />
             </NavLink>
+            <Favorite />
           </div>
         )}
       </div>

--- a/src/components/ui/Favorite.tsx
+++ b/src/components/ui/Favorite.tsx
@@ -1,19 +1,24 @@
 import { useDAOData } from '../../contexts/daoData';
 import { useWeb3 } from '../../contexts/web3Data';
 import useFavorites from '../../hooks/useFavorites';
-import Button from './forms/Button';
+import { StarFilled, StarEmpty } from '../ui/svg/Star';
+import TooltipWrapper from '../ui/TooltipWrapper';
 
-function FavoriteButton({ label, onClick }: { label: string; onClick: (() => void) | undefined }) {
+function FavoriteButton({
+  icon,
+  onClick,
+}: {
+  icon: React.ReactElement;
+  onClick: (() => void) | undefined;
+}) {
   return (
-    <Button
-      isLarge={false}
-      label={label}
-      onClick={onClick}
-    />
+    <div className="flex items-center">
+      <button onClick={onClick}>{icon}</button>
+    </div>
   );
 }
 
-function Favorite() {
+function Buttons() {
   const [{ chainId }] = useWeb3();
   const [{ daoAddress }] = useDAOData();
   const { isFavorite, addFavorite, removeFavorite } = useFavorites();
@@ -21,7 +26,7 @@ function Favorite() {
   if (chainId === undefined || daoAddress === undefined) {
     return (
       <FavoriteButton
-        label="is no fav"
+        icon={<StarEmpty />}
         onClick={undefined}
       />
     );
@@ -31,19 +36,37 @@ function Favorite() {
 
   if (fav) {
     return (
-      <FavoriteButton
-        label="is fav"
-        onClick={() => removeFavorite(chainId, daoAddress)}
-      />
+      <TooltipWrapper
+        isVisible={true}
+        content="Remove from favorites"
+      >
+        <FavoriteButton
+          icon={<StarFilled />}
+          onClick={() => removeFavorite(chainId, daoAddress)}
+        />
+      </TooltipWrapper>
     );
   } else {
     return (
-      <FavoriteButton
-        label="is no fav"
-        onClick={() => addFavorite(chainId, daoAddress)}
-      />
+      <TooltipWrapper
+        isVisible={true}
+        content="Add to favorites"
+      >
+        <FavoriteButton
+          icon={<StarEmpty />}
+          onClick={() => addFavorite(chainId, daoAddress)}
+        />
+      </TooltipWrapper>
     );
   }
+}
+
+function Favorite() {
+  return (
+    <div className="text-gold-500 mr-2 font-sans text-sm">
+      <Buttons />
+    </div>
+  );
 }
 
 export default Favorite;

--- a/src/components/ui/Favorite.tsx
+++ b/src/components/ui/Favorite.tsx
@@ -1,0 +1,49 @@
+import { useDAOData } from '../../contexts/daoData';
+import { useWeb3 } from '../../contexts/web3Data';
+import useFavorites from '../../hooks/useFavorites';
+import Button from './forms/Button';
+
+function FavoriteButton({ label, onClick }: { label: string; onClick: (() => void) | undefined }) {
+  return (
+    <Button
+      isLarge={false}
+      label={label}
+      onClick={onClick}
+    />
+  );
+}
+
+function Favorite() {
+  const [{ chainId }] = useWeb3();
+  const [{ daoAddress }] = useDAOData();
+  const { isFavorite, addFavorite, removeFavorite } = useFavorites();
+
+  if (chainId === undefined || daoAddress === undefined) {
+    return (
+      <FavoriteButton
+        label="is no fav"
+        onClick={undefined}
+      />
+    );
+  }
+
+  const fav = isFavorite(chainId, daoAddress);
+
+  if (fav) {
+    return (
+      <FavoriteButton
+        label="is fav"
+        onClick={() => removeFavorite(chainId, daoAddress)}
+      />
+    );
+  } else {
+    return (
+      <FavoriteButton
+        label="is no fav"
+        onClick={() => addFavorite(chainId, daoAddress)}
+      />
+    );
+  }
+}
+
+export default Favorite;

--- a/src/components/ui/Header/MenuItems.tsx
+++ b/src/components/ui/Header/MenuItems.tsx
@@ -4,6 +4,7 @@ import Contact from '../svg/Contact';
 import Support from '../svg/Support';
 import Connect from '../svg/Connect';
 import Disconnect from '../svg/Disconnect';
+import { StarEmpty } from '../svg/Star';
 import Faq from '../svg/Faq';
 import Docs from '../svg/Docs';
 import CopyToClipboard from '../CopyToClipboard';
@@ -53,7 +54,7 @@ const DOCS: LinkMenuItem = {
 const FAVORITES: LinkMenuItem = {
   title: 'Favorites',
   link: '/daos/favorites',
-  Icon: () => <div>?</div>,
+  Icon: StarEmpty,
 };
 
 const CONNECT_WALLET = (connect: () => void): ActionMenuItem => ({

--- a/src/components/ui/Header/MenuItems.tsx
+++ b/src/components/ui/Header/MenuItems.tsx
@@ -10,6 +10,7 @@ import CopyToClipboard from '../CopyToClipboard';
 import EtherscanLink from '../EtherscanLink';
 import useDisplayName from '../../../hooks/useDisplayName';
 import cx from 'classnames';
+import { Link } from 'react-router-dom';
 
 interface MenuItem {
   title: string;
@@ -49,6 +50,12 @@ const DOCS: LinkMenuItem = {
   Icon: Docs,
 };
 
+const FAVORITES: LinkMenuItem = {
+  title: 'Favorites',
+  link: '/daos/favorites',
+  Icon: () => <div>?</div>,
+};
+
 const CONNECT_WALLET = (connect: () => void): ActionMenuItem => ({
   title: 'Connect Wallet',
   action: connect,
@@ -81,6 +88,23 @@ function ItemWrapper(props: {
   );
 }
 
+function ItemContent({
+  title,
+  className,
+  Icon,
+}: {
+  title: string;
+  className?: string;
+  Icon: () => JSX.Element;
+}) {
+  return (
+    <ItemWrapper className={className}>
+      <Icon />
+      <span>{title}</span>
+    </ItemWrapper>
+  );
+}
+
 function ActionItem({ title, className, action, Icon, isVisible }: ActionMenuItem) {
   if (!isVisible) {
     return null;
@@ -91,10 +115,11 @@ function ActionItem({ title, className, action, Icon, isVisible }: ActionMenuIte
         onClick={action}
         className={cx('w-full', className)}
       >
-        <ItemWrapper className={className}>
-          <Icon />
-          <span>{title}</span>
-        </ItemWrapper>
+        <ItemContent
+          title={title}
+          className={className}
+          Icon={Icon}
+        />
       </button>
     </Menu.Item>
   );
@@ -108,11 +133,24 @@ function LinkItem({ title, link, Icon }: LinkMenuItem) {
         target="_blank"
         rel="noopener noreferrer"
       >
-        <ItemWrapper>
-          <Icon />
-          <span>{title}</span>
-        </ItemWrapper>
+        <ItemContent
+          title={title}
+          Icon={Icon}
+        />
       </a>
+    </Menu.Item>
+  );
+}
+
+function LinkItemInternal({ title, link, Icon }: LinkMenuItem) {
+  return (
+    <Menu.Item>
+      <Link to={link}>
+        <ItemContent
+          title={title}
+          Icon={Icon}
+        />
+      </Link>
     </Menu.Item>
   );
 }
@@ -153,6 +191,7 @@ function MenuItems() {
           />
         </section>
         <section className="border-t border-gray-300">
+          <LinkItemInternal {...FAVORITES} />
           <LinkItem {...COMMUNITY} />
           <LinkItem {...OVERVIEW} />
           <LinkItem {...FAQ} />

--- a/src/components/ui/svg/Star.tsx
+++ b/src/components/ui/svg/Star.tsx
@@ -1,0 +1,35 @@
+function StarFilled() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 18.26L4.94704 22.208L6.52204 14.28L0.587036 8.792L8.61404 7.84L12 0.5L15.386 7.84L23.413 8.792L17.478 14.28L19.053 22.208L12 18.26Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function StarEmpty() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 18.26L4.947 22.208L6.522 14.28L0.586998 8.792L8.614 7.84L12 0.5L15.386 7.84L23.413 8.792L17.478 14.28L19.053 22.208L12 18.26ZM12 15.968L16.247 18.345L15.298 13.572L18.871 10.267L14.038 9.694L12 5.275L9.962 9.695L5.129 10.267L8.702 13.572L7.753 18.345L12 15.968V15.968Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+export { StarFilled, StarEmpty };

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -1,0 +1,72 @@
+import { ethers } from 'ethers';
+import { useLocalStorage } from './useLocalStorage';
+
+type Favorites = {
+  [chainId: number]: string[];
+};
+
+const useFavorites = () => {
+  const [favorites, setFavorites] = useLocalStorage('favorites', {} as Favorites);
+
+  const isFavorite = (chainId: number, address: string) => {
+    if (favorites[chainId] === undefined) {
+      return false;
+    }
+
+    try {
+      // This might throw
+      const normalizedAddress = ethers.utils.getAddress(address);
+      return favorites[chainId].includes(normalizedAddress);
+    } catch (e: unknown) {
+      console.error(e);
+      return false;
+    }
+  };
+
+  const addFavorite = (chainId: number, address: string) => {
+    try {
+      // This might throw
+      const normalizedAddress = ethers.utils.getAddress(address);
+      if (favorites[chainId] === undefined) {
+        // No favs for this chain exists, but favs for other chains might exist.
+        // So, make sure to apply this single new fav for this chain into the existing
+        // favs object.
+        setFavorites(Object.assign({}, favorites, { [chainId]: [normalizedAddress] }));
+      } else {
+        // Favs for this chain already exist.
+        const newFavorites = Object.assign({}, favorites);
+        // So, just need to add one more fav address into existing array.
+        newFavorites[chainId] = [...newFavorites[chainId], normalizedAddress];
+        setFavorites(newFavorites);
+      }
+    } catch (e: unknown) {
+      console.error(e);
+      return;
+    }
+  };
+
+  const removeFavorite = (chainId: number, address: string) => {
+    if (favorites[chainId] === undefined) {
+      return;
+    }
+
+    try {
+      // This might throw
+      const normalizedAddress = ethers.utils.getAddress(address);
+
+      const newFavorites = Object.assign({}, favorites);
+      newFavorites[chainId] = newFavorites[chainId].filter(
+        favoriteAddress => favoriteAddress !== normalizedAddress
+      );
+
+      setFavorites(newFavorites);
+    } catch (e: unknown) {
+      console.error(e);
+      return;
+    }
+  };
+
+  return { favorites, isFavorite, addFavorite, removeFavorite };
+};
+
+export default useFavorites;

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+
+function getStorageValue<T>(key: string, defaultValue: T) {
+  // getting stored value
+  const saved = localStorage.getItem(key);
+  if (saved === null) {
+    return defaultValue;
+  }
+
+  const initial: T = JSON.parse(saved);
+  return initial || defaultValue;
+}
+
+export function useLocalStorage<T>(key: string, defaultValue: T) {
+  const [value, setValue] = useState(() => {
+    return getStorageValue(key, defaultValue);
+  });
+
+  useEffect(() => {
+    // storing input name
+    localStorage.setItem(key, JSON.stringify(value));
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}

--- a/src/pages/DaoFavorites/index.tsx
+++ b/src/pages/DaoFavorites/index.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import ContentBox from '../../components/ui/ContentBox';
+import { TextButton } from '../../components/ui/forms/Button';
+import H1 from '../../components/ui/H1';
+import useDAOContract from '../../contexts/daoData/useDAOContract';
+import useDAOName from '../../contexts/daoData/useDAOName';
+import { useWeb3 } from '../../contexts/web3Data';
+import useFavorites from '../../hooks/useFavorites';
+import useIsDAO from '../../hooks/useIsDAO';
+
+function FavoriteRow({ address }: { address: string }) {
+  const [isDAO, isDAOLoading] = useIsDAO(address);
+  const daoName = useDAOName(useDAOContract(address));
+  const [daoNameDisplay, setDAONameDisplay] = useState('...');
+
+  useEffect(() => {
+    if (isDAOLoading) {
+      setDAONameDisplay('...');
+      return;
+    }
+
+    if (!isDAO) {
+      setDAONameDisplay('unknown');
+      return;
+    }
+
+    if (!daoName) {
+      setDAONameDisplay('...');
+      return;
+    }
+
+    setDAONameDisplay(daoName);
+  }, [isDAOLoading, isDAO, daoName]);
+
+  return (
+    <div className="py-4 first:pt-0 last:pb-0 border-b border-gray-100 last:border-b-0 truncate">
+      <div>{daoNameDisplay}</div>
+      <div className="text-xs">
+        <Link to={`/daos/${address}`}>
+          <TextButton
+            label={`(${address})`}
+            className="-ml-4"
+          />
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function DAOFavorites() {
+  const [{ chainId }] = useWeb3();
+  const { favorites } = useFavorites();
+
+  const [chainFavorites, setChainFavorites] = useState<string[]>([]);
+  useEffect(() => {
+    if (!chainId) {
+      setChainFavorites([]);
+      return;
+    }
+
+    setChainFavorites(favorites[chainId]);
+  }, [favorites, chainId]);
+
+  return (
+    <div className="text-gray-25">
+      <H1>Favorite Fractals</H1>
+      <ContentBox>
+        {chainFavorites.length === 0 ? (
+          <div>No favorites!</div>
+        ) : (
+          <div>
+            {chainFavorites.map(favorite => (
+              <FavoriteRow
+                key={favorite}
+                address={favorite}
+              />
+            ))}
+          </div>
+        )}
+      </ContentBox>
+    </div>
+  );
+}
+
+export default DAOFavorites;

--- a/src/pages/DaoFavorites/index.tsx
+++ b/src/pages/DaoFavorites/index.tsx
@@ -35,8 +35,8 @@ function FavoriteRow({ address }: { address: string }) {
 
   return (
     <div className="py-4 first:pt-0 last:pb-0 border-b border-gray-100 last:border-b-0 truncate">
-      <div>{daoNameDisplay}</div>
-      <div className="text-xs">
+      <div className="text-lg">{daoNameDisplay}</div>
+      <div>
         <Link to={`/daos/${address}`}>
           <TextButton
             label={address}

--- a/src/pages/DaoFavorites/index.tsx
+++ b/src/pages/DaoFavorites/index.tsx
@@ -39,7 +39,7 @@ function FavoriteRow({ address }: { address: string }) {
       <div className="text-xs">
         <Link to={`/daos/${address}`}>
           <TextButton
-            label={`(${address})`}
+            label={address}
             className="-ml-4"
           />
         </Link>

--- a/src/pages/DaoFavorites/index.tsx
+++ b/src/pages/DaoFavorites/index.tsx
@@ -59,6 +59,11 @@ function DAOFavorites() {
       return;
     }
 
+    if (!favorites[chainId]) {
+      setChainFavorites([]);
+      return;
+    }
+
     setChainFavorites(favorites[chainId]);
   }, [favorites, chainId]);
 

--- a/src/pages/Daos/index.tsx
+++ b/src/pages/Daos/index.tsx
@@ -1,7 +1,7 @@
 import { Routes, Route } from 'react-router-dom';
 import DAOSearch from '../DaoSearch';
-
 import DaoCreate from '../DaoCreate';
+import DAOFavorites from '../DaoFavorites';
 import DAO from '../Dao';
 
 // @todo refactor route files to own directory
@@ -15,6 +15,10 @@ function DAOs() {
       <Route
         path="new"
         element={<DaoCreate />}
+      />
+      <Route
+        path="favorites"
+        element={<DAOFavorites />}
       />
       <Route
         path=":address/*"


### PR DESCRIPTION
Closes #266 

# Adds the ability for user to manually mark "favorite" DAOs.

<img width="1199" alt="Screen Shot 2022-06-10 at 1 36 16 AM" src="https://user-images.githubusercontent.com/706929/172997501-1629b3d2-f583-4e52-a885-9a993b3a5ea8.png">

- Adds new page to list all "Favorite DAOs" .
  - Note: this page only shows favorited DAOs for the connected network.
  - Note: Favorited DAOs are saved/stored/retrieved per network.
- Adds new item to user menu called "Favorites".
  - That item links to the new Favorites page.
  - TODO: @xraystyle1980 if you're able, I could use a "heart" icon for this dropdown.
- Each entry in the list displays the DAO Name, address, and the address is a link to that DAO within the Fractal interface.

<img width="1174" alt="Screen Shot 2022-06-10 at 1 39 50 AM" src="https://user-images.githubusercontent.com/706929/172997943-535cc06b-6fb9-43ed-93b6-e1585c00d2b6.png">

- In each DAO, a "button" exists to toggle the Favorite status for that DAO
  - Right now, those "buttons" are just text that say `is fav` and `is not fav` lol.
  - TODO: @xraystyle1980 if you're able, I could use hollow and filled "heart" icons to act as a button showing "favorite" status.

### Notes

This implementation is not made to be feature-rich. It was written to be basic yet functional for what it is.