### PR TITLE
Pause for 2 seconds before informing app that Transaction is completed

### DIFF
--- a/src/contexts/web3Data/transactions.ts
+++ b/src/contexts/web3Data/transactions.ts
@@ -61,7 +61,13 @@ const useTransaction = () => {
           if (params.failedCallback) params.failedCallback();
         }
         if (params.completedCallback) params.completedCallback();
-        setPending(false);
+
+        // Give the block event emitter a couple seconds to play the latest
+        // block on the app state, before informing app that the transaction
+        // is completed.
+        setTimeout(() => {
+          setPending(false);
+        }, 2000);
       })
       .catch((error: ProviderRpcError) => {
         console.error(error);


### PR DESCRIPTION
Closes #306 

Adds a 2 second delay after transaction is mined, before reporting back to the business logic layer that that the transaction is no longer pending.