### PR TITLE
reAdds 'loading' phase of provider

### DIFF
--- a/src/contexts/web3Data/Web3Provider.tsx
+++ b/src/contexts/web3Data/Web3Provider.tsx
@@ -17,18 +17,13 @@ const initialState: InitialState = {
   network: '',
   chainId: 0,
   provider: null,
+  isProviderLoading: false,
 };
 
 const getInitialState = () => {
-  if (process.env.REACT_APP_LOCAL_PROVIDER_URL && process.env.NODE_ENV === 'development') {
-    return {
-      ...initialState,
-      ...getLocalProvider(),
-    };
-  }
   return {
     ...initialState,
-    ...getFallbackProvider(),
+    isProviderLoading: true,
   };
 };
 
@@ -45,6 +40,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         connectionType,
         network,
         chainId,
+        isProviderLoading: false,
       };
     }
     case Web3ProviderActions.SET_LOCAL_PROVIDER:
@@ -57,6 +53,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         network,
         chainId,
         signerOrProvider,
+        isProviderLoading: false,
       };
     }
     case Web3ProviderActions.DISCONNECT_WALLET: {

--- a/src/contexts/web3Data/types.ts
+++ b/src/contexts/web3Data/types.ts
@@ -14,6 +14,7 @@ export interface InitialState {
   provider: Providers | null;
   account: string | null;
   signerOrProvider: ethers.Signer | Providers | null;
+  isProviderLoading: boolean;
 }
 
 export type InjectedProviderInfo = {

--- a/src/pages/Dao/index.tsx
+++ b/src/pages/Dao/index.tsx
@@ -62,7 +62,7 @@ function DAO() {
   const location = useLocation();
   const navigate = useNavigate();
   const {
-    state: { account, chainId },
+    state: { account, chainId, isProviderLoading },
   } = useWeb3Provider();
   const [, setAddress] = useDAOData();
   useValidateDaoRoute();
@@ -80,13 +80,13 @@ function DAO() {
   }, [location]);
 
   useEffect(() => {
-    if (account) {
+    if (account || isProviderLoading) {
       return;
     }
 
     navigate('/', { replace: true });
     toast('Connect a wallet to load a DAO');
-  }, [account, navigate]);
+  }, [account, navigate, isProviderLoading]);
 
   // when this component unloads, setAddress back to undefined to clear app state
   useEffect(() => () => setAddress(undefined), [setAddress]);


### PR DESCRIPTION
## Overview

I had originally thought that the 'loading' boolean for provider was no longer needed. but when on a page that requires an account and it is refreshed there is a moment before the account it is loading that it will be null and this needs to be tracked.

Solution. reAdding the `isProviderLoading` boolean and setting that true during the initial load. 