### PR TITLE
connects to default provider on load

### DIFF
--- a/src/contexts/web3Data/Web3Provider.tsx
+++ b/src/contexts/web3Data/Web3Provider.tsx
@@ -106,8 +106,10 @@ export function Web3Provider({ children }: { children: React.ReactNode }) {
   const load = useCallback(() => {
     if (web3Modal.cachedProvider) {
       connect();
+      return;
     }
-  }, [connect]);
+    connectDefaultProvider();
+  }, [connect, connectDefaultProvider]);
 
   useEffect(() => load(), [load]);
 


### PR DESCRIPTION
## Overview

Updated Web3Provider to connect to defaultProvider (fallback or local) on load when no cacheProvider. A missing update from last PR when adding a loading state