### PR TITLE
daoData module structure

### DIFF
--- a/src/components/Dao/Delegate.tsx
+++ b/src/components/Dao/Delegate.tsx
@@ -23,7 +23,13 @@ function Delegate() {
   const [, validAddress] = useAddress(newDelegatee);
   const [
     {
-      tokenData: { decimals, symbol, userBalance, delegatee, votingWeight },
+      modules: {
+        governor: {
+          votingToken: {
+            votingTokenData: { decimals, symbol, userBalance, delegatee, votingWeight },
+          },
+        },
+      },
     },
   ] = useDAOData();
   const delegateeDisplayName = useDisplayName(delegatee);

--- a/src/components/Dao/Details.tsx
+++ b/src/components/Dao/Details.tsx
@@ -28,7 +28,19 @@ function AddressDisplay({ address, label }: AddressDisplayProps) {
 }
 
 function Details() {
-  const [{ name, accessControlAddress, moduleAddresses, tokenData, daoAddress }] = useDAOData();
+  const [
+    {
+      name,
+      accessControlAddress,
+      moduleAddresses,
+      daoAddress,
+      modules: {
+        governor: {
+          votingToken: { votingTokenData },
+        },
+      },
+    },
+  ] = useDAOData();
 
   return (
     <div>
@@ -50,7 +62,7 @@ function Details() {
         </InputBox>
         <InputBox>
           <AddressDisplay
-            address={tokenData.address}
+            address={votingTokenData.address}
             label="Governance Token Address:"
           />
         </InputBox>

--- a/src/components/Proposals/ProposalDetails.tsx
+++ b/src/components/Proposals/ProposalDetails.tsx
@@ -11,7 +11,13 @@ import CastVote from './CastVote';
 function ProposalDetails() {
   const params = useParams();
 
-  const [{ proposals }] = useDAOData();
+  const [
+    {
+      modules: {
+        governor: { proposals },
+      },
+    },
+  ] = useDAOData();
   const [proposal, setProposal] = useState<ProposalData>();
 
   useEffect(() => {

--- a/src/components/Proposals/ProposalsList.tsx
+++ b/src/components/Proposals/ProposalsList.tsx
@@ -2,7 +2,13 @@ import { useDAOData } from '../../contexts/daoData';
 import ProposalCard from './ProposalCard';
 
 function ProposalsList() {
-  const [{ proposals }] = useDAOData();
+  const [
+    {
+      modules: {
+        governor: { proposals },
+      },
+    },
+  ] = useDAOData();
 
   if (proposals === undefined) {
     return <div className="text-white">Proposals loading...</div>;

--- a/src/contexts/blockchainData/blockchainData.ts
+++ b/src/contexts/blockchainData/blockchainData.ts
@@ -1,9 +1,12 @@
+import { MetaFactory } from '../../assets/typechain-types/metafactory';
 import useCurrentBlockNumber from './useCurrentBlockNumber';
 import useCurrentTimestamp from './useCurrentTimestamp';
+import useMetaFactoryContract from './useMetaFactoryContract';
 
 export interface BlockchainData {
   currentBlockNumber: number | undefined;
   currentTimestamp: number;
+  metaFactoryContract: MetaFactory | undefined;
 }
 
 export type BlockchainDataContext = BlockchainData;
@@ -13,10 +16,12 @@ export const defaultBlockchainDataResponse = {} as BlockchainData;
 const useBlockchainDatas = () => {
   const currentBlockNumber = useCurrentBlockNumber();
   const currentTimestamp = useCurrentTimestamp(currentBlockNumber);
+  const metaFactoryContract = useMetaFactoryContract();
 
   const blockchainData: BlockchainData = {
     currentBlockNumber,
     currentTimestamp,
+    metaFactoryContract,
   };
 
   return blockchainData;

--- a/src/contexts/blockchainData/useMetaFactoryContract.ts
+++ b/src/contexts/blockchainData/useMetaFactoryContract.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+import { useWeb3Provider } from '../web3Data/hooks/useWeb3Provider';
+import { MetaFactory, MetaFactory__factory } from '../../assets/typechain-types/metafactory';
+import { useAddresses } from '../daoData/useAddresses';
+
+const useMetaFactoryContract = () => {
+  const [metaFactoryContract, setMetaFactoryContract] = useState<MetaFactory>();
+  const {
+    state: { signerOrProvider, chainId },
+  } = useWeb3Provider();
+
+  const { metaFactory } = useAddresses(chainId);
+
+  useEffect(() => {
+    if (!metaFactory || !signerOrProvider) {
+      setMetaFactoryContract(undefined);
+      return;
+    }
+
+    setMetaFactoryContract(MetaFactory__factory.connect(metaFactory.address, signerOrProvider));
+  }, [metaFactory, signerOrProvider]);
+
+  return metaFactoryContract;
+};
+
+export default useMetaFactoryContract;

--- a/src/contexts/daoData/daoData.ts
+++ b/src/contexts/daoData/daoData.ts
@@ -24,20 +24,28 @@ export interface DAOData {
   name: string | undefined;
   accessControlAddress: string | undefined;
   moduleAddresses: string[] | undefined;
-  proposals: ProposalData[] | undefined;
-  governorModuleContract: GovernorModule | undefined;
-  tokenContract: VotesTokenWithSupply | undefined;
-  tokenData: {
-    name: string | undefined;
-    symbol: string | undefined;
-    decimals: number | undefined;
-    userBalance: BigNumber | undefined;
-    delegatee: string | undefined;
-    votingWeight: BigNumber | undefined;
-    address: string | undefined;
+  modules: {
+    treasury: {
+      treasuryModuleContract: TreasuryModule | undefined;
+      treasuryAssets: TreasuryAsset[];
+    };
+    governor: {
+      governorModuleContract: GovernorModule | undefined;
+      proposals: ProposalData[] | undefined;
+      votingToken: {
+        votingTokenContract: VotesTokenWithSupply | undefined;
+        votingTokenData: {
+          name: string | undefined;
+          symbol: string | undefined;
+          decimals: number | undefined;
+          userBalance: BigNumber | undefined;
+          delegatee: string | undefined;
+          votingWeight: BigNumber | undefined;
+          address: string | undefined;
+        };
+      };
+    };
   };
-  treasuryModuleContract?: TreasuryModule;
-  treasuryAssets: TreasuryAsset[];
 }
 
 type SetDAOAddressFn = React.Dispatch<React.SetStateAction<string | undefined>>;
@@ -69,8 +77,8 @@ const useDAODatas = () => {
   );
   // ************************* //
 
-  const tokenContract = useTokenContract(governorModuleContract);
-  const tokenData = useTokenData(tokenContract);
+  const votingTokenContract = useTokenContract(governorModuleContract);
+  const votingTokenData = useTokenData(votingTokenContract);
   const { currentBlockNumber } = useBlockchainData();
   const proposals = useProposals(governorModuleContract, currentBlockNumber);
   const daoData: DAOData = {
@@ -78,12 +86,20 @@ const useDAODatas = () => {
     name,
     accessControlAddress,
     moduleAddresses,
-    proposals,
-    governorModuleContract,
-    tokenContract,
-    tokenData,
-    treasuryModuleContract,
-    treasuryAssets,
+    modules: {
+      treasury: {
+        treasuryModuleContract,
+        treasuryAssets,
+      },
+      governor: {
+        governorModuleContract,
+        proposals,
+        votingToken: {
+          votingTokenContract,
+          votingTokenData,
+        },
+      },
+    },
   };
 
   return [daoData, setDAOAddress] as const;

--- a/src/contexts/daoData/useGovernorModuleContract.ts
+++ b/src/contexts/daoData/useGovernorModuleContract.ts
@@ -8,17 +8,17 @@ import { useWeb3Provider } from '../web3Data/hooks/useWeb3Provider';
 const useGovernorModuleContract = (moduleAddresses: string[] | undefined) => {
   const [governorModule, setGovernorModule] = useState<GovernorModule>();
   const {
-    state: { provider },
+    state: { signerOrProvider },
   } = useWeb3Provider();
 
   useEffect(() => {
-    if (moduleAddresses === undefined || moduleAddresses[1] === undefined || !provider) {
+    if (moduleAddresses === undefined || moduleAddresses[1] === undefined || !signerOrProvider) {
       setGovernorModule(undefined);
       return;
     }
 
-    setGovernorModule(GovernorModule__factory.connect(moduleAddresses[1], provider));
-  }, [moduleAddresses, provider]);
+    setGovernorModule(GovernorModule__factory.connect(moduleAddresses[1], signerOrProvider));
+  }, [moduleAddresses, signerOrProvider]);
 
   return governorModule;
 };

--- a/src/hooks/useCastVote.ts
+++ b/src/hooks/useCastVote.ts
@@ -16,7 +16,13 @@ const useCastVote = ({
   const {
     state: { signerOrProvider },
   } = useWeb3Provider();
-  const [{ governorModuleContract }] = useDAOData();
+  const [
+    {
+      modules: {
+        governor: { governorModuleContract },
+      },
+    },
+  ] = useDAOData();
 
   const [contractCallCastVote, contractCallPending] = useTransaction();
 

--- a/src/hooks/useCastVote.ts
+++ b/src/hooks/useCastVote.ts
@@ -2,7 +2,6 @@ import { useWeb3Provider } from './../contexts/web3Data/hooks/useWeb3Provider';
 import { useCallback, useEffect } from 'react';
 import { useTransaction } from '../contexts/web3Data/transactions';
 import { BigNumber } from 'ethers';
-import { GovernorModule, GovernorModule__factory } from '../assets/typechain-types/module-governor';
 import { useDAOData } from '../contexts/daoData/index';
 
 const useCastVote = ({
@@ -17,7 +16,7 @@ const useCastVote = ({
   const {
     state: { signerOrProvider },
   } = useWeb3Provider();
-  const [daoData] = useDAOData();
+  const [{ governorModuleContract }] = useDAOData();
 
   const [contractCallCastVote, contractCallPending] = useTransaction();
 
@@ -25,29 +24,23 @@ const useCastVote = ({
     setPending(contractCallPending);
   }, [setPending, contractCallPending]);
 
-  let castVote = useCallback(() => {
+  const castVote = useCallback(() => {
     if (
       !signerOrProvider ||
-      daoData.moduleAddresses === undefined ||
+      governorModuleContract === undefined ||
       proposalId === undefined ||
       vote === undefined
     ) {
       return;
     }
 
-    // @todo we could probably just pull contract from state here.
-    const governor: GovernorModule = GovernorModule__factory.connect(
-      daoData.moduleAddresses[1],
-      signerOrProvider
-    );
-
     contractCallCastVote({
-      contractFn: () => governor.castVote(proposalId, vote),
+      contractFn: () => governorModuleContract.castVote(proposalId, vote),
       pendingMessage: 'Casting Vote',
       failedMessage: 'Vote Cast Failed',
       successMessage: 'Vote Casted',
     });
-  }, [contractCallCastVote, daoData.moduleAddresses, proposalId, signerOrProvider, vote]);
+  }, [contractCallCastVote, governorModuleContract, proposalId, signerOrProvider, vote]);
   return castVote;
 };
 

--- a/src/hooks/useCreateProposal.ts
+++ b/src/hooks/useCreateProposal.ts
@@ -27,7 +27,13 @@ const useCreateProposal = ({
     state: { signerOrProvider },
   } = useWeb3Provider();
   const navigate = useNavigate();
-  const [{ governorModuleContract }] = useDAOData();
+  const [
+    {
+      modules: {
+        governor: { governorModuleContract },
+      },
+    },
+  ] = useDAOData();
 
   const [contractCallCreateProposal, contractCallPending] = useTransaction();
 

--- a/src/hooks/useCreateProposal.ts
+++ b/src/hooks/useCreateProposal.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect } from 'react';
 import { useTransaction } from '../contexts/web3Data/transactions';
 import { BigNumber } from 'ethers';
 import { useNavigate } from 'react-router-dom';
-import { GovernorModule, GovernorModule__factory } from '../assets/typechain-types/module-governor';
 import { useDAOData } from '../contexts/daoData/index';
 import { useWeb3Provider } from '../contexts/web3Data/hooks/useWeb3Provider';
 
@@ -28,7 +27,7 @@ const useCreateProposal = ({
     state: { signerOrProvider },
   } = useWeb3Provider();
   const navigate = useNavigate();
-  const [daoData] = useDAOData();
+  const [{ governorModuleContract }] = useDAOData();
 
   const [contractCallCreateProposal, contractCallPending] = useTransaction();
 
@@ -37,18 +36,13 @@ const useCreateProposal = ({
   }, [setPending, contractCallPending]);
 
   let createProposal = useCallback(() => {
-    if (!signerOrProvider || !proposalData || !setPending || !daoData || !daoData.moduleAddresses) {
+    if (!signerOrProvider || !proposalData || !setPending || !governorModuleContract) {
       return;
     }
 
-    const governor: GovernorModule = GovernorModule__factory.connect(
-      daoData.moduleAddresses[1],
-      signerOrProvider
-    );
-
     contractCallCreateProposal({
       contractFn: () =>
-        governor.propose(
+        governorModuleContract.propose(
           proposalData.targets,
           proposalData.values,
           proposalData.calldatas,
@@ -66,7 +60,7 @@ const useCreateProposal = ({
     daoAddress,
     navigate,
     contractCallCreateProposal,
-    daoData,
+    governorModuleContract,
     proposalData,
     setPending,
     signerOrProvider,

--- a/src/hooks/useDelegateVote.ts
+++ b/src/hooks/useDelegateVote.ts
@@ -9,22 +9,30 @@ const useDelegateVote = ({
   delegatee: string | undefined;
   successCallback: () => void;
 }) => {
-  const [{ tokenContract }] = useDAOData();
+  const [
+    {
+      modules: {
+        governor: {
+          votingToken: { votingTokenContract },
+        },
+      },
+    },
+  ] = useDAOData();
   const [contractCallDelegateVote, contractCallPending] = useTransaction();
 
   let delegateVote = useCallback(() => {
-    if (tokenContract === undefined || delegatee === undefined) {
+    if (votingTokenContract === undefined || delegatee === undefined) {
       return;
     }
 
     contractCallDelegateVote({
-      contractFn: () => tokenContract.delegate(delegatee),
+      contractFn: () => votingTokenContract.delegate(delegatee),
       pendingMessage: 'Delegating Vote',
       failedMessage: 'Vote Delegation Failed',
       successMessage: 'Vote Delegated',
       successCallback: () => successCallback(),
     });
-  }, [contractCallDelegateVote, tokenContract, delegatee, successCallback]);
+  }, [contractCallDelegateVote, votingTokenContract, delegatee, successCallback]);
 
   return [delegateVote, contractCallPending] as const;
 };

--- a/src/hooks/useDeployDAO.ts
+++ b/src/hooks/useDeployDAO.ts
@@ -2,9 +2,9 @@ import { useCallback, useEffect } from 'react';
 import { useTransaction } from '../contexts/web3Data/transactions';
 import { useNavigate } from 'react-router-dom';
 import { BigNumber, ethers } from 'ethers';
-import { MetaFactory, MetaFactory__factory } from '../assets/typechain-types/metafactory';
 import { useAddresses } from '../contexts/daoData/useAddresses';
 import { useWeb3Provider } from '../contexts/web3Data/hooks/useWeb3Provider';
+import { useBlockchainData } from '../contexts/blockchainData';
 
 export type TokenAllocation = {
   address: string;
@@ -49,6 +49,8 @@ const useDeployDAO = ({
   const [contractCallDeploy, contractCallPending] = useTransaction();
   const navigate = useNavigate();
 
+  const { metaFactoryContract } = useBlockchainData();
+
   useEffect(() => {
     setPending(contractCallPending);
   }, [setPending, contractCallPending]);
@@ -66,15 +68,12 @@ const useDeployDAO = ({
       !addresses.tokenFactory?.address ||
       !addresses.governorFactory?.address ||
       !addresses.governorModule?.address ||
-      !addresses.timelockUpgradeable?.address
+      !addresses.timelockUpgradeable?.address ||
+      !metaFactoryContract
     ) {
       return;
     }
 
-    const factory: MetaFactory = MetaFactory__factory.connect(
-      addresses.metaFactory?.address,
-      signerOrProvider
-    );
     const abiCoder = new ethers.utils.AbiCoder();
 
     const createDAOParams = {
@@ -174,7 +173,7 @@ const useDeployDAO = ({
     };
     contractCallDeploy({
       contractFn: () =>
-        factory.createDAOAndModules(
+        metaFactoryContract.createDAOAndModules(
           addresses.daoFactory?.address!,
           0,
           createDAOParams,
@@ -225,6 +224,7 @@ const useDeployDAO = ({
     addresses.timelockUpgradeable?.address,
     contractCallDeploy,
     navigate,
+    metaFactoryContract,
   ]);
   return deployDao;
 };

--- a/src/hooks/useExecuteTransaction.ts
+++ b/src/hooks/useExecuteTransaction.ts
@@ -15,7 +15,13 @@ const useExecuteTransaction = ({
   const {
     state: { signerOrProvider },
   } = useWeb3Provider();
-  const [{ governorModuleContract }] = useDAOData();
+  const [
+    {
+      modules: {
+        governor: { governorModuleContract },
+      },
+    },
+  ] = useDAOData();
 
   const [contractCallExecuteTransaction, contractCallPending] = useTransaction();
 

--- a/src/hooks/useExecuteTransaction.ts
+++ b/src/hooks/useExecuteTransaction.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect } from 'react';
 import { useTransaction } from '../contexts/web3Data/transactions';
-import { GovernorModule, GovernorModule__factory } from '../assets/typechain-types/module-governor';
 import { useDAOData } from '../contexts/daoData/index';
 import { ProposalData } from '../contexts/daoData/useProposals';
 import { ethers } from 'ethers';
@@ -16,7 +15,7 @@ const useExecuteTransaction = ({
   const {
     state: { signerOrProvider },
   } = useWeb3Provider();
-  const [daoData] = useDAOData();
+  const [{ governorModuleContract }] = useDAOData();
 
   const [contractCallExecuteTransaction, contractCallPending] = useTransaction();
 
@@ -25,17 +24,13 @@ const useExecuteTransaction = ({
   }, [setPending, contractCallPending]);
 
   let executeTransaction = useCallback(() => {
-    if (!signerOrProvider || !proposalData || !daoData || !daoData.moduleAddresses) {
+    if (!signerOrProvider || !proposalData || !governorModuleContract) {
       return;
     }
 
-    const governor: GovernorModule = GovernorModule__factory.connect(
-      daoData.moduleAddresses[1],
-      signerOrProvider
-    );
     contractCallExecuteTransaction({
       contractFn: () =>
-        governor.execute(
+        governorModuleContract.execute(
           proposalData.targets,
           [0],
           proposalData.calldatas,
@@ -45,7 +40,7 @@ const useExecuteTransaction = ({
       failedMessage: 'Executing Failed',
       successMessage: 'Executing Completed',
     });
-  }, [contractCallExecuteTransaction, daoData, proposalData, signerOrProvider]);
+  }, [contractCallExecuteTransaction, governorModuleContract, proposalData, signerOrProvider]);
   return executeTransaction;
 };
 

--- a/src/hooks/useQueueTransaction.ts
+++ b/src/hooks/useQueueTransaction.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect } from 'react';
 import { useTransaction } from '../contexts/web3Data/transactions';
-import { GovernorModule, GovernorModule__factory } from '../assets/typechain-types/module-governor';
 import { useDAOData } from '../contexts/daoData/index';
 import { ProposalData } from '../contexts/daoData/useProposals';
 import { ethers } from 'ethers';
@@ -16,7 +15,7 @@ const useQueueTransaction = ({
   const {
     state: { signerOrProvider },
   } = useWeb3Provider();
-  const [daoData] = useDAOData();
+  const [{ governorModuleContract }] = useDAOData();
 
   const [contractCallQueueTransaction, contractCallPending] = useTransaction();
 
@@ -25,17 +24,13 @@ const useQueueTransaction = ({
   }, [setPending, contractCallPending]);
 
   let queueTransaction = useCallback(() => {
-    if (!signerOrProvider || !proposalData || !daoData || !daoData.moduleAddresses) {
+    if (!signerOrProvider || !proposalData || !governorModuleContract) {
       return;
     }
 
-    const governor: GovernorModule = GovernorModule__factory.connect(
-      daoData.moduleAddresses[1],
-      signerOrProvider
-    );
     contractCallQueueTransaction({
       contractFn: () =>
-        governor.queue(
+        governorModuleContract.queue(
           proposalData.targets,
           [0],
           proposalData.calldatas,
@@ -45,7 +40,7 @@ const useQueueTransaction = ({
       failedMessage: 'Queuing Failed',
       successMessage: 'Queuing Completed',
     });
-  }, [contractCallQueueTransaction, daoData, proposalData, signerOrProvider]);
+  }, [contractCallQueueTransaction, governorModuleContract, proposalData, signerOrProvider]);
   return queueTransaction;
 };
 

--- a/src/hooks/useQueueTransaction.ts
+++ b/src/hooks/useQueueTransaction.ts
@@ -15,7 +15,13 @@ const useQueueTransaction = ({
   const {
     state: { signerOrProvider },
   } = useWeb3Provider();
-  const [{ governorModuleContract }] = useDAOData();
+  const [
+    {
+      modules: {
+        governor: { governorModuleContract },
+      },
+    },
+  ] = useDAOData();
 
   const [contractCallQueueTransaction, contractCallPending] = useTransaction();
 

--- a/src/pages/Treasury/index.tsx
+++ b/src/pages/Treasury/index.tsx
@@ -16,7 +16,14 @@ function TableRowWrapper({ children }: { children?: ReactNode }) {
 }
 
 function Treasury() {
-  const [{ treasuryAssets, name, treasuryModuleContract }] = useDAOData();
+  const [
+    {
+      name,
+      modules: {
+        treasury: { treasuryAssets, treasuryModuleContract },
+      },
+    },
+  ] = useDAOData();
   return (
     <div>
       <H1>{name} Treasury</H1>


### PR DESCRIPTION
- Add some more structure to the `daoData`, made it less flat, to break the "governor" and "treasury" module data into their own sections.
- Use the global instance of the Governor contract throughout components, instead of always creating new instances of it whenever a transaction was being made to it.
- Add a global MetaFactory contract instance to the global `useBlockchainData` return object (didn't put in `daoData` cause it's not part of a DAO).