### PR TITLE
Find modules

### DIFF
--- a/src/components/Dao/Details.tsx
+++ b/src/components/Dao/Details.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { useDAOData } from '../../contexts/daoData';
 import ContentBox from '../ui/ContentBox';
 import ContentBoxTitle from '../ui/ContentBoxTitle';
@@ -8,13 +9,18 @@ import H1 from '../ui/H1';
 
 interface AddressDisplayProps {
   address?: string;
-  label: string;
+  label: string | Promise<string>;
 }
 
 function AddressDisplay({ address, label }: AddressDisplayProps) {
+  const [lbl, setLbl] = useState('');
+  useEffect(() => {
+    Promise.resolve(label).then(setLbl);
+  }, [label]);
+
   return (
     <div>
-      <div className="text-sm font-medium text-gray-50 pb-1">{label}</div>
+      <div className="text-sm font-medium text-gray-50 pb-1">{lbl}</div>
       <div className="flex items-center">
         <EtherscanLink address={address}>
           <div className="text-gold-500 hover:text-gold-300 font-semibold tracking-wider font-mono break-all">
@@ -32,12 +38,14 @@ function Details() {
     {
       name,
       accessControlAddress,
-      moduleAddresses,
       daoAddress,
       modules: {
         governor: {
+          governorModuleContract,
+          timelockModuleContract,
           votingToken: { votingTokenData },
         },
+        treasury: { treasuryModuleContract },
       },
     },
   ] = useDAOData();
@@ -46,50 +54,51 @@ function Details() {
     <div>
       <H1>{name}</H1>
       <ContentBox>
-        <ContentBoxTitle>DAO Address</ContentBoxTitle>
+        <ContentBoxTitle>Core DAO Address</ContentBoxTitle>
         <InputBox>
           <AddressDisplay
             address={daoAddress}
-            label=""
+            label="DAO"
           />
         </InputBox>
-        <ContentBoxTitle>DAO Contracts Addresses</ContentBoxTitle>
         <InputBox>
           <AddressDisplay
             address={accessControlAddress}
-            label="Access Control Address:"
+            label="Access Control"
           />
         </InputBox>
+        <ContentBoxTitle>Module Contract Addresses</ContentBoxTitle>
+        {treasuryModuleContract && (
+          <InputBox>
+            <AddressDisplay
+              address={treasuryModuleContract.address}
+              label={treasuryModuleContract.name()}
+            />
+          </InputBox>
+        )}
+        {governorModuleContract && (
+          <InputBox>
+            <AddressDisplay
+              address={governorModuleContract.address}
+              label={governorModuleContract.name()}
+            />
+          </InputBox>
+        )}
+        {timelockModuleContract && (
+          <InputBox>
+            <AddressDisplay
+              address={timelockModuleContract.address}
+              label={timelockModuleContract.name()}
+            />
+          </InputBox>
+        )}
+        <ContentBoxTitle>Auxiliary Contracts Addresses</ContentBoxTitle>
         <InputBox>
           <AddressDisplay
             address={votingTokenData.address}
-            label="Governance Token Address:"
+            label="Governance Token"
           />
         </InputBox>
-
-        {moduleAddresses && moduleAddresses.length && (
-          <>
-            <ContentBoxTitle>Module Contract Addresses</ContentBoxTitle>
-            <InputBox>
-              <AddressDisplay
-                address={moduleAddresses[0]}
-                label="Treasury Module Address:"
-              />
-            </InputBox>
-            <InputBox>
-              <AddressDisplay
-                address={moduleAddresses[1]}
-                label="Governor Module Address:"
-              />
-            </InputBox>
-            <InputBox>
-              <AddressDisplay
-                address={moduleAddresses[2]}
-                label="Timelock Controller Module Address:"
-              />
-            </InputBox>
-          </>
-        )}
       </ContentBox>
     </div>
   );

--- a/src/contexts/daoData/daoData.ts
+++ b/src/contexts/daoData/daoData.ts
@@ -24,7 +24,6 @@ export interface DAOData {
   daoAddress: string | undefined;
   name: string | undefined;
   accessControlAddress: string | undefined;
-  moduleAddresses: string[] | undefined;
   modules: {
     treasury: {
       treasuryModuleContract: TreasuryModule | undefined;
@@ -88,7 +87,6 @@ const useDAODatas = () => {
     daoAddress,
     name,
     accessControlAddress,
-    moduleAddresses,
     modules: {
       treasury: {
         treasuryModuleContract,

--- a/src/contexts/daoData/daoData.ts
+++ b/src/contexts/daoData/daoData.ts
@@ -7,10 +7,11 @@ import useAccessControlAddress from './useAccessControlAddress';
 import useAccessControlContract from './useAccessControlContract';
 import useModuleAddresses from './useModuleAddresses';
 import useGovernorModuleContract from './useGovernorModuleContract';
+import useTimelockModuleContract from './useTimelockModuleContract';
 import useTokenContract from './useTokenContract';
 import useTokenData from './useTokenData';
 import useProposals, { ProposalData } from './useProposals';
-import { GovernorModule } from '../../assets/typechain-types/module-governor';
+import { GovernorModule, TimelockUpgradeable } from '../../assets/typechain-types/module-governor';
 import { TreasuryModule } from '../../assets/typechain-types/module-treasury';
 import { VotesTokenWithSupply } from '../../assets/typechain-types/votes-token';
 import { useBlockchainData } from '../blockchainData';
@@ -31,6 +32,7 @@ export interface DAOData {
     };
     governor: {
       governorModuleContract: GovernorModule | undefined;
+      timelockModuleContract: TimelockUpgradeable | undefined;
       proposals: ProposalData[] | undefined;
       votingToken: {
         votingTokenContract: VotesTokenWithSupply | undefined;
@@ -66,6 +68,7 @@ const useDAODatas = () => {
 
   // ***** Module Hooks ****** //
   const governorModuleContract = useGovernorModuleContract(moduleAddresses);
+  const timelockModuleContract = useTimelockModuleContract(moduleAddresses);
   const treasuryModuleContract = useTreasuryModuleContract(moduleAddresses);
   const { nativeDeposits, nativeWithdraws, erc20TokenDeposits, erc20TokenWithdraws } =
     useTreasuryEvents(treasuryModuleContract);
@@ -93,6 +96,7 @@ const useDAODatas = () => {
       },
       governor: {
         governorModuleContract,
+        timelockModuleContract,
         proposals,
         votingToken: {
           votingTokenContract,

--- a/src/contexts/daoData/treasury/useTreasuryModuleContract.ts
+++ b/src/contexts/daoData/treasury/useTreasuryModuleContract.ts
@@ -2,27 +2,42 @@ import { useEffect, useState } from 'react';
 import {
   TreasuryModule,
   TreasuryModule__factory,
+  ITreasuryModule__factory,
 } from '../../../assets/typechain-types/module-treasury';
 import { useWeb3Provider } from '../../web3Data/hooks/useWeb3Provider';
+import use165Contracts from '../../../hooks/use165Contracts';
+import useSupportsInterfaces from '../../../hooks/useSupportsInterfaces';
+import { IModuleBase__factory } from '@fractal-framework/core-contracts';
 
-const useTreasuryModuleContract = (moduleAddresses?: string[]) => {
-  const {
-    state: { provider },
-  } = useWeb3Provider();
+const useTreasuryModuleContract = (moduleAddresses: string[] | undefined) => {
   const [treasuryModule, setTreasuryModule] = useState<TreasuryModule>();
+  const {
+    state: { signerOrProvider },
+  } = useWeb3Provider();
+
+  const [contracts] = use165Contracts(moduleAddresses);
+  const [interfaces] = useState([
+    IModuleBase__factory.createInterface(),
+    ITreasuryModule__factory.createInterface(),
+  ]);
+
+  const [potentialTreasuries] = useSupportsInterfaces(contracts, interfaces);
 
   useEffect(() => {
-    if (
-      moduleAddresses === undefined ||
-      !moduleAddresses.length ||
-      !moduleAddresses[0] ||
-      !provider
-    ) {
+    if (potentialTreasuries === undefined || !signerOrProvider) {
       setTreasuryModule(undefined);
       return;
     }
-    setTreasuryModule(TreasuryModule__factory.connect(moduleAddresses[0], provider));
-  }, [moduleAddresses, provider]);
+
+    const treasury = potentialTreasuries.find(t => t.match === true);
+    if (treasury === undefined) {
+      setTreasuryModule(undefined);
+      return;
+    }
+
+    setTreasuryModule(TreasuryModule__factory.connect(treasury.address, signerOrProvider));
+  }, [potentialTreasuries, signerOrProvider, moduleAddresses]);
+
   return treasuryModule;
 };
 

--- a/src/hooks/use165Contracts.ts
+++ b/src/hooks/use165Contracts.ts
@@ -3,28 +3,28 @@ import { useState, useEffect } from 'react';
 import { IERC165, IERC165__factory } from '@fractal-framework/core-contracts';
 import { useWeb3Provider } from '../contexts/web3Data/hooks/useWeb3Provider';
 
-const use165Contract = (address: string | undefined) => {
+const use165Contracts = (addresses: string[] | undefined) => {
   const {
     state: { provider },
   } = useWeb3Provider();
 
-  const [contract, setContract] = useState<IERC165>();
+  const [contracts, setContracts] = useState<IERC165[]>();
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     setLoading(true);
 
-    if (!provider || !address || address.trim() === '') {
-      setContract(undefined);
+    if (!provider || !addresses) {
+      setContracts(undefined);
       setLoading(false);
       return;
     }
 
-    setContract(IERC165__factory.connect(address, provider));
+    setContracts(addresses.map(address => IERC165__factory.connect(address, provider)));
     setLoading(false);
-  }, [provider, address]);
+  }, [provider, addresses]);
 
-  return [contract, loading] as const;
+  return [contracts, loading] as const;
 };
 
-export default use165Contract;
+export default use165Contracts;

--- a/src/hooks/useIsDAO.ts
+++ b/src/hooks/useIsDAO.ts
@@ -1,23 +1,37 @@
 import { useEffect, useState } from 'react';
 
-import use165Contract from './use165Contract';
+import use165Contracts from './use165Contracts';
 import { IDAO__factory, IModuleBase__factory } from '@fractal-framework/core-contracts';
 import useSupportsInterfaces from './useSupportsInterfaces';
 
 const useIsDAO = (address: string | undefined) => {
-  const [contract, contractLoading] = use165Contract(address);
+  const [potentialDAOContract, setPotentialDAOContract] = useState<string[]>();
+  useEffect(() => {
+    if (address === undefined) {
+      setPotentialDAOContract(undefined);
+      return;
+    }
+
+    setPotentialDAOContract([address]);
+  }, [address]);
+
+  const [contracts, contractsLoading] = use165Contracts(potentialDAOContract);
   const [interfaces] = useState([
-    IDAO__factory.createInterface(),
     IModuleBase__factory.createInterface(),
+    IDAO__factory.createInterface(),
   ]);
-  const [isDAO, isDAOLoading] = useSupportsInterfaces(contract, interfaces);
+  const [isDAO, isDAOLoading] = useSupportsInterfaces(contracts, interfaces);
 
   const [loading, setLoading] = useState(false);
   useEffect(() => {
-    setLoading(contractLoading || isDAOLoading);
-  }, [contractLoading, isDAOLoading]);
+    setLoading(contractsLoading || isDAOLoading);
+  }, [contractsLoading, isDAOLoading]);
 
-  return [isDAO, loading] as const;
+  if (isDAO === undefined) {
+    return [undefined, loading] as const;
+  }
+
+  return [isDAO[0].match, loading] as const;
 };
 
 export default useIsDAO;

--- a/src/hooks/useSupportsInterfaces.ts
+++ b/src/hooks/useSupportsInterfaces.ts
@@ -3,26 +3,37 @@ import { utils } from 'ethers';
 
 import { ERC165 } from '@fractal-framework/core-contracts';
 import useInterfaceSelectors from './useInterfaceSelectors';
+import { ContractMatch } from '../types/contractMatch';
 
-const useSupportsInterfaces = (contract: ERC165 | undefined, interfaces: utils.Interface[]) => {
-  const [supportsInterfaces, setSupportsInterfaces] = useState<boolean>();
+const useSupportsInterfaces = (contracts: ERC165[] | undefined, interfaces: utils.Interface[]) => {
+  const [supportsInterfaces, setSupportsInterfaces] = useState<ContractMatch[]>();
   const interfaceSelectors = useInterfaceSelectors(interfaces);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     setLoading(true);
 
-    if (!contract || !interfaceSelectors) {
+    if (!contracts || !interfaceSelectors) {
       setSupportsInterfaces(undefined);
       setLoading(false);
       return;
     }
 
-    Promise.all(interfaceSelectors.map(selector => contract.supportsInterface(selector)))
-      .then(supports => setSupportsInterfaces(supports.reduce((p, c) => p && c)))
-      .catch(() => setSupportsInterfaces(false))
+    Promise.all(
+      contracts.map(contract =>
+        Promise.all(
+          interfaceSelectors.map(selector =>
+            contract.supportsInterface(selector).catch(() => false)
+          )
+        ).then(contractSupports => ({
+          address: contract.address,
+          match: contractSupports.reduce((p, c) => p && c),
+        }))
+      )
+    )
+      .then(allContractsSupports => setSupportsInterfaces(allContractsSupports))
       .finally(() => setLoading(false));
-  }, [contract, interfaceSelectors]);
+  }, [contracts, interfaceSelectors]);
 
   return [supportsInterfaces, loading] as const;
 };

--- a/src/types/contractMatch.ts
+++ b/src/types/contractMatch.ts
@@ -1,0 +1,4 @@
+export type ContractMatch = {
+  address: string;
+  match: boolean;
+};


### PR DESCRIPTION
Build in support to "look for" the Treasury, Governor, and Timelock modules dynamically at runtime, instead of hardcoding their "index" in the `moduleAddresses` array.