### PR TITLE
prevent component from rendering when not connected

### DIFF
--- a/src/components/ui/Header/MenuItems.tsx
+++ b/src/components/ui/Header/MenuItems.tsx
@@ -158,7 +158,9 @@ function LinkItemInternal({ title, link, Icon }: LinkMenuItem) {
 
 function AddressCopyItem({ account }: { account: string | null }) {
   const { accountDisplayName } = useBlockchainData();
-
+  if (!account) {
+    return null;
+  }
   return (
     <ItemWrapper noHoverEffect>
       <span className="text-gold-300">


### PR DESCRIPTION
## Overview

Noticed that the copy icon was showing up when account wasn't connected. added a conditional to prevent rendering