### PR TITLE
412 delegate error state reset

### DIFF
--- a/src/components/Dao/Delegate.tsx
+++ b/src/components/Dao/Delegate.tsx
@@ -17,6 +17,7 @@ import { useGovenorModule } from '../../providers/govenor/hooks/useGovenorModule
 function Delegate() {
   const [newDelegatee, setNewDelegatee] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState('');
+
   const {
     state: { account },
   } = useWeb3Provider();
@@ -52,6 +53,7 @@ function Delegate() {
   }, [decimals, userBalance, symbol]);
 
   const [readableVotingWeight, setReadableVotingWeight] = useState<string>();
+
   useEffect(() => {
     if (votingWeight === undefined || decimals === undefined || symbol === undefined) {
       setReadableVotingWeight(undefined);
@@ -64,6 +66,8 @@ function Delegate() {
   useEffect(() => {
     if (validAddress === false) {
       setErrorMessage('Invalid address');
+    } else {
+      setErrorMessage('');
     }
   }, [validAddress]);
   return (

--- a/src/components/Dao/Delegate.tsx
+++ b/src/components/Dao/Delegate.tsx
@@ -44,10 +44,7 @@ function Delegate() {
     return `${utils.formatUnits(votingWeight, decimals)} ${symbol}`;
   }, [decimals, votingWeight, symbol]);
 
-  const errorMessage = useMemo(
-    () => (validAddress === false ? 'Invalid address' : undefined),
-    [validAddress]
-  );
+  const errorMessage = validAddress === false ? 'Invalid address' : undefined;
 
   const delegateSelf = () => {
     if (!account) {

--- a/src/components/Dao/Delegate.tsx
+++ b/src/components/Dao/Delegate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { utils } from 'ethers';
 import useDelegateVote from '../../hooks/useDelegateVote';
 import useDisplayName from '../../hooks/useDisplayName';
@@ -16,18 +16,38 @@ import { useGovenorModule } from '../../providers/govenor/hooks/useGovenorModule
 
 function Delegate() {
   const [newDelegatee, setNewDelegatee] = useState<string>('');
-  const [errorMessage, setErrorMessage] = useState('');
 
   const {
     state: { account },
   } = useWeb3Provider();
+
   const [, validAddress] = useAddress(newDelegatee);
+
   const {
     votingToken: {
       votingTokenData: { decimals, symbol, userBalance, delegatee, votingWeight },
     },
   } = useGovenorModule();
   const delegateeDisplayName = useDisplayName(delegatee);
+
+  const readableBalance = useMemo(() => {
+    if (!userBalance || !decimals || !symbol) {
+      return;
+    }
+    return `${utils.formatUnits(userBalance, decimals)} ${symbol}`;
+  }, [decimals, userBalance, symbol]);
+
+  const readableVotingWeight = useMemo(() => {
+    if (!votingWeight || !decimals || !symbol) {
+      return;
+    }
+    return `${utils.formatUnits(votingWeight, decimals)} ${symbol}`;
+  }, [decimals, votingWeight, symbol]);
+
+  const errorMessage = useMemo(
+    () => (validAddress === false ? 'Invalid address' : undefined),
+    [validAddress]
+  );
 
   const delegateSelf = () => {
     if (!account) {
@@ -42,34 +62,6 @@ function Delegate() {
     successCallback: () => setNewDelegatee(''),
   });
 
-  const [readableBalance, setReadableBalance] = useState<string>();
-  useEffect(() => {
-    if (userBalance === undefined || decimals === undefined || symbol === undefined) {
-      setReadableBalance(undefined);
-      return;
-    }
-
-    setReadableBalance(`${utils.formatUnits(userBalance, decimals)} ${symbol}`);
-  }, [decimals, userBalance, symbol]);
-
-  const [readableVotingWeight, setReadableVotingWeight] = useState<string>();
-
-  useEffect(() => {
-    if (votingWeight === undefined || decimals === undefined || symbol === undefined) {
-      setReadableVotingWeight(undefined);
-      return;
-    }
-
-    setReadableVotingWeight(`${utils.formatUnits(votingWeight, decimals)} ${symbol}`);
-  }, [decimals, votingWeight, symbol]);
-
-  useEffect(() => {
-    if (validAddress === false) {
-      setErrorMessage('Invalid address');
-    } else {
-      setErrorMessage('');
-    }
-  }, [validAddress]);
   return (
     <>
       <div className="flex flex-col bg-gray-600 my-4 p-2 py-2 rounded-md">


### PR DESCRIPTION
## Overview

Fixes bug where Delegate Input error state would not reset.

## Additional Changes
Saw an opportunity to clean up this file a little with replacing `useState` + `useEffect` with `useMemo`. I looked up to confirm what I was thinking that this way would be more performant. https://stackoverflow.com/questions/56028913/usememo-vs-useeffect-usestate

closes #412 