### PR TITLE
414 Parent Token Allocation updating during execution

### DIFF
--- a/src/hooks/useCreateDAODataCreator.ts
+++ b/src/hooks/useCreateDAODataCreator.ts
@@ -15,7 +15,7 @@ import {
 } from '../assets/typechain-types/votes-token';
 import { TreasuryModule__factory } from '../assets/typechain-types/metafactory';
 
-type ICreateDAOData = (
+type CreateDAOData = (
   data: {
     creator: string;
     daoName: string;
@@ -41,7 +41,7 @@ const useCreateDAODataCreator = () => {
 
   const addresses = useAddresses(chainId);
 
-  const createDAOData = useCallback<ICreateDAOData>(
+  const createDAOData = useCallback<CreateDAOData>(
     (
       {
         creator,


### PR DESCRIPTION
## Overview

### Problem
When Executing the create a SubDAO plugin, As the data is being prepared to be submitted it was pushing to `tokenAllocations`. Because of `currentBlockNumber` rerendering down the tree from the `useBlockChainDatas()` This push was causing the state to update in the form, which would sometimes cause an error when trying to submit the proposal, without a clear error.

### Solution
Cloning the array and then pushing to that when executing prevents state from being updated.