### PR TITLE
Choose Governance DAO Creation Components

### DIFF
--- a/src/components/DaoCreator/ChooseGovernance.tsx
+++ b/src/components/DaoCreator/ChooseGovernance.tsx
@@ -1,0 +1,49 @@
+import ContentBox from '../ui/ContentBox';
+import { RadioWithText } from '../ui/forms/Radio/RadioWithText';
+import { useCreator } from './provider/hooks/useCreator';
+import { CreatorProviderActions, GovernanceTypes } from './provider/types';
+
+export function ChooseGovernance() {
+  const {
+    state: { governance },
+    dispatch,
+  } = useCreator();
+
+  const fieldUpdate = (value: any) => {
+    dispatch({
+      type: CreatorProviderActions.UPDATE_GOVERNANCE,
+      payload: value,
+    });
+  };
+
+  return (
+    <div>
+      <ContentBox>
+        <div className="md:grid md:grid-cols-2 gap-6 flex flex-col items-center py-4">
+          <RadioWithText
+            label="1:1 Token Voting"
+            description="Governance with tokens giving voting power to token holders."
+            name="governance"
+            id="token-voting"
+            isSelected={governance === GovernanceTypes.TOKEN_VOTING_GOVERNANCE}
+            onChange={() => {
+              fieldUpdate(GovernanceTypes.TOKEN_VOTING_GOVERNANCE);
+            }}
+            readOnly
+          />
+          <RadioWithText
+            label="Gnosis Safe"
+            description="Gnosis Powered, Multi-signature governance allows you define an access/control-scheme through multiple signers that need to confirm transactions"
+            id="gnosis-safe"
+            name="governance"
+            isSelected={governance === GovernanceTypes.GNOSIS_SAFE}
+            onChange={() => {
+              fieldUpdate(GovernanceTypes.GNOSIS_SAFE);
+            }}
+            readOnly
+          />
+        </div>
+      </ContentBox>
+    </div>
+  );
+}

--- a/src/components/DaoCreator/ChooseGovernance.tsx
+++ b/src/components/DaoCreator/ChooseGovernance.tsx
@@ -9,7 +9,7 @@ export function ChooseGovernance() {
     dispatch,
   } = useCreator();
 
-  const fieldUpdate = (value: any) => {
+  const fieldUpdate = (value: GovernanceTypes) => {
     dispatch({
       type: CreatorProviderActions.UPDATE_GOVERNANCE,
       payload: value,
@@ -17,33 +17,31 @@ export function ChooseGovernance() {
   };
 
   return (
-    <div>
-      <ContentBox>
-        <div className="md:grid md:grid-cols-2 gap-6 flex flex-col items-center py-4">
-          <RadioWithText
-            label="1:1 Token Voting"
-            description="Governance with tokens giving voting power to token holders."
-            name="governance"
-            id="token-voting"
-            isSelected={governance === GovernanceTypes.TOKEN_VOTING_GOVERNANCE}
-            onChange={() => {
-              fieldUpdate(GovernanceTypes.TOKEN_VOTING_GOVERNANCE);
-            }}
-            readOnly
-          />
-          <RadioWithText
-            label="Gnosis Safe"
-            description="Gnosis Powered, Multi-signature governance allows you define an access/control-scheme through multiple signers that need to confirm transactions"
-            id="gnosis-safe"
-            name="governance"
-            isSelected={governance === GovernanceTypes.GNOSIS_SAFE}
-            onChange={() => {
-              fieldUpdate(GovernanceTypes.GNOSIS_SAFE);
-            }}
-            readOnly
-          />
-        </div>
-      </ContentBox>
-    </div>
+    <ContentBox>
+      <div className="md:grid md:grid-cols-2 gap-6 flex flex-col items-center py-4">
+        <RadioWithText
+          label="1:1 Token Voting"
+          description="Governance with tokens giving voting power to token holders."
+          name="governance"
+          id="token-voting"
+          isSelected={governance === GovernanceTypes.TOKEN_VOTING_GOVERNANCE}
+          onChange={() => {
+            fieldUpdate(GovernanceTypes.TOKEN_VOTING_GOVERNANCE);
+          }}
+          readOnly
+        />
+        <RadioWithText
+          label="Gnosis Safe"
+          description="Gnosis Powered, Multi-signature governance allows you define an access/control-scheme through multiple signers that need to confirm transactions"
+          id="gnosis-safe"
+          name="governance"
+          isSelected={governance === GovernanceTypes.GNOSIS_SAFE}
+          onChange={() => {
+            fieldUpdate(GovernanceTypes.GNOSIS_SAFE);
+          }}
+          readOnly
+        />
+      </div>
+    </ContentBox>
   );
 }

--- a/src/components/DaoCreator/DisplayStepController.tsx
+++ b/src/components/DaoCreator/DisplayStepController.tsx
@@ -4,12 +4,15 @@ import { CreatorSteps } from './provider/types';
 import { SubsidiaryFunding } from './SubsidiaryFunding';
 import TokenDetails from './TokenDetails';
 import GovernanceDetails from './GovernanceDetails';
+import { ChooseGovernance } from './ChooseGovernance';
 
 function StepController() {
   const { state } = useCreator();
   switch (state.step) {
     case CreatorSteps.ESSENTIALS:
       return <DAODetails />;
+    case CreatorSteps.CHOOSE_GOVERNANCE:
+      return <ChooseGovernance />;
     case CreatorSteps.FUNDING: {
       return <SubsidiaryFunding />;
     }

--- a/src/components/DaoCreator/provider/CreatorProvider.tsx
+++ b/src/components/DaoCreator/provider/CreatorProvider.tsx
@@ -16,12 +16,14 @@ import {
   CreatorState,
   CreatorSteps,
   DAOTrigger,
+  GovernanceTypes,
 } from './types';
 
 export const initialState: CreatorState = {
   step: CreatorSteps.ESSENTIALS,
   prevStep: null,
   nextStep: null,
+  governance: GovernanceTypes.TOKEN_VOTING_GOVERNANCE,
   essentials: {
     daoName: '',
   },
@@ -50,6 +52,8 @@ const reducer = (state: CreatorState, action: CreatorProviderActionTypes) => {
   switch (action.type) {
     case CreatorProviderActions.UPDATE_ESSENTIALS:
       return { ...state, essentials: { ...state.essentials, ...action.payload } };
+    case CreatorProviderActions.UPDATE_GOVERNANCE:
+      return { ...state, governance: action.payload };
     case CreatorProviderActions.UPDATE_FUNDING:
       return { ...state, funding: { ...state.funding, ...action.payload } };
     case CreatorProviderActions.UPDATE_TREASURY_GOV_TOKEN:

--- a/src/components/DaoCreator/provider/constants/index.ts
+++ b/src/components/DaoCreator/provider/constants/index.ts
@@ -2,7 +2,8 @@ import { CreatorSteps } from '../types';
 
 export const CREATOR_STEP_TITLES = {
   [CreatorSteps.ESSENTIALS]: 'Configure Essentials',
+  [CreatorSteps.CHOOSE_GOVERNANCE]: 'Choose Governance',
   [CreatorSteps.TREASURY_GOV_TOKEN]: 'Treasury and Governance Token',
-  [CreatorSteps.GOV_CONFIG]: 'Governance',
+  [CreatorSteps.GOV_CONFIG]: 'Governance Configuration',
   [CreatorSteps.FUNDING]: 'Funding',
 };

--- a/src/components/DaoCreator/provider/types/index.ts
+++ b/src/components/DaoCreator/provider/types/index.ts
@@ -5,6 +5,7 @@ export enum CreatorProviderActions {
   SET_STEP,
   UPDATE_ESSENTIALS,
   UPDATE_TREASURY_GOV_TOKEN,
+  UPDATE_GOVERNANCE,
   UPDATE_GOV_CONFIG,
   UPDATE_FUNDING,
   UPDATE_STEP,
@@ -12,10 +13,16 @@ export enum CreatorProviderActions {
 }
 
 export enum CreatorSteps {
+  CHOOSE_GOVERNANCE,
   ESSENTIALS,
   FUNDING,
   TREASURY_GOV_TOKEN,
   GOV_CONFIG,
+}
+
+export enum GovernanceTypes {
+  TOKEN_VOTING_GOVERNANCE,
+  GNOSIS_SAFE,
 }
 
 export type CreatorProviderActionTypes =
@@ -23,6 +30,7 @@ export type CreatorProviderActionTypes =
       type: CreatorProviderActions.UPDATE_ESSENTIALS;
       payload: DAOEssentials;
     }
+  | { type: CreatorProviderActions.UPDATE_GOVERNANCE; payload: GovernanceTypes }
   | { type: CreatorProviderActions.UPDATE_TREASURY_GOV_TOKEN; payload: DAOGovenorToken }
   | { type: CreatorProviderActions.UPDATE_GOV_CONFIG; payload: DAOGovenorModuleConfig }
   | { type: CreatorProviderActions.UPDATE_FUNDING; payload: DAOFunding }
@@ -66,6 +74,7 @@ export interface CreatorState {
   step: CreatorSteps;
   nextStep: CreatorSteps | null;
   prevStep: CreatorSteps | null;
+  governance: GovernanceTypes;
   essentials: DAOEssentials;
   govToken: DAOGovenorToken;
   govModule: DAOGovenorModuleConfig;

--- a/src/components/ui/forms/Radio/RadioWithText.tsx
+++ b/src/components/ui/forms/Radio/RadioWithText.tsx
@@ -1,0 +1,50 @@
+import React, { ChangeEvent } from 'react';
+import cx from 'classnames';
+
+interface IRadioWithText {
+  description: string;
+  id: string;
+  name: string;
+  isSelected: boolean;
+  label: string;
+  onChange: (e: ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLDivElement>) => void;
+  value?: any;
+  readOnly?: boolean;
+}
+
+export function RadioWithText({
+  description,
+  id,
+  isSelected,
+  label,
+  onChange,
+  ...rest
+}: IRadioWithText) {
+  return (
+    <div
+      className={cx('p-4 bg-gray-500 flex border h-full', {
+        'border-gray-50': isSelected,
+        'border-gray-400': !isSelected,
+      })}
+      onClick={onChange}
+    >
+      <div className="flex items-center">
+        <input
+          id={id}
+          type="radio"
+          checked={isSelected}
+          {...rest}
+        />
+      </div>
+      <div className="pl-4">
+        <label
+          className="font-mono font-bold"
+          htmlFor={id}
+        >
+          {label}
+        </label>
+        <div className="mt-2 text-gray-50">{description}</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Overview

First part of adding support for creating a DAO with Gnosis Safe Governance. 

## Screenshot
![image](https://user-images.githubusercontent.com/38386583/184965610-9d66871f-b241-49b6-a057-2fa63d160436.png)


## Changes

- Creates UI components for Choosing Governance
- Updates Creator Provider to store this information in state and dispatch to update it.

## Notes
- Current this 'step' isn't included in the flow, so on the deploy site you will not be able to see it. If you want to view this page as it is. Pull down locally and change the `step` in `CreatorProvider` on line 23 to `CHOOSE_GOVERNANCE`. 
- The next PR will add this into the flow up to Deployment.

 