### PR TITLE
Update random byte generation code to be way more random

### DIFF
--- a/src/helpers/crypto.ts
+++ b/src/helpers/crypto.ts
@@ -1,9 +1,10 @@
 import { ethers } from 'ethers';
 
 export function getRandomSalt() {
-  return ethers.utils.formatBytes32String(
-    self.crypto.getRandomValues(new BigUint64Array(1))[0].toString()
-  );
+  const bytes8Array = new Uint8Array(32);
+  self.crypto.getRandomValues(bytes8Array);
+  const bytes32 = '0x' + bytes8Array.reduce((o, v) => o + ('00' + v.toString(16)).slice(-2), '');
+  return bytes32;
 }
 
 /**


### PR DESCRIPTION
Original implementation produced "random 32 byte output" that looked like this (5 runs):

```
0x3136353030313932343636373834353935303438000000000000000000000000
0x3938383230373432363135353534383534353300000000000000000000000000
0x3432303730363134303735363932333532343800000000000000000000000000
0x3532323331373830313138333530313833393000000000000000000000000000
0x3234303332313132303933383834373131313700000000000000000000000000
```

New implementation produces "random 32 byte output" that looks like this (5 runs):

```
0x1ccff0d6a7c692aa72a689b1f96a61050ae19b7586955e052dc972d2d093be3d
0x91210c5d5bd957f42921873404db8dee4881766e5cd75cab144662641c519257
0x8045bd6b9a2122f629cfe28e2861eb79518efeaa84a491257fbf91d6ece31dba
0x05210e7ddc801216f37d2cf5783a5f6d56436e4e35758be7c590ca0c9ca3cb25
0xc022eb2926378c619e2b7a3bb8a5e585a8cf73c2706784be6e0b945362567775
```