### PR TITLE
BugFIx Token Supply/Amount Error

### DIFF
--- a/src/hooks/useCreateDAODataCreator.ts
+++ b/src/hooks/useCreateDAODataCreator.ts
@@ -173,8 +173,8 @@ const useCreateDAODataCreator = () => {
             [
               tokenName,
               tokenSymbol,
-              tokenAllocations.map(tokenAllocation => tokenAllocation.address),
-              tokenAllocations.map(tokenAllocation =>
+              tokenAllocationData.map(tokenAllocation => tokenAllocation.address),
+              tokenAllocationData.map(tokenAllocation =>
                 ethers.utils.parseUnits(tokenAllocation.amount.toString(), 18)
               ),
             ]


### PR DESCRIPTION
Thankfully this bug was not caused by any math error, rather it caused by the update that changed from using the `tokenAllocation` prop. The prediction was mapping the original prop array and not the updated array with the additional allocations