### PR TITLE
Deploy a Gnosis Safe SubDAO with Token Voting Parent DAO

### DIFF
--- a/src/controller/Modules/TokenGovernanceInjector.tsx
+++ b/src/controller/Modules/TokenGovernanceInjector.tsx
@@ -72,7 +72,7 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
 
       const data: ExecuteData = {
         targets: [metaFactoryContract.address],
-        values: [0],
+        values: [BigNumber.from('0')],
         calldatas: [
           metaFactoryContract.interface.encodeFunctionData('createDAOAndExecute', [
             newDAOData.calldata.daoFactory,
@@ -92,7 +92,7 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
             // ERC20 transfer
             // Approve the new treasury to transfer tokens from the DAO
             data.targets.push(tokenToFund.asset.contractAddress);
-            data.values.push(0);
+            data.values.push(BigNumber.from('0'));
             data.calldatas.push(
               ERC20__factory.createInterface().encodeFunctionData('approve', [
                 newDAOData.predictedTreasuryAddress,
@@ -102,7 +102,7 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
 
             // Withdraw tokens from the parent treasury into the parent DAO
             data.targets.push(treasuryModuleContract.address);
-            data.values.push(0);
+            data.values.push(BigNumber.from('0'));
             data.calldatas.push(
               TreasuryModule__factory.createInterface().encodeFunctionData('withdrawERC20Tokens', [
                 [tokenToFund.asset.contractAddress],
@@ -135,7 +135,7 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
             // ETH Transfer
             // Withdraw ETH from the parent treasury into the parent DAO
             data.targets.push(treasuryModuleContract.address);
-            data.values.push(0);
+            data.values.push(BigNumber.from('0'));
             data.calldatas.push(
               TreasuryModule__factory.createInterface().encodeFunctionData('withdrawEth', [
                 [newDAOData.predictedTreasuryAddress],
@@ -155,7 +155,7 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
         // Approve the new treasury to transfer tokens from the DAO
         daoData.nftsToFund.forEach(erc721Fund => {
           data.targets.push(erc721Fund.asset.contractAddress);
-          data.values.push(0);
+          data.values.push(BigNumber.from('0'));
           data.calldatas.push(
             ERC721__factory.createInterface().encodeFunctionData('approve', [
               newDAOData.predictedTreasuryAddress,
@@ -166,7 +166,7 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
 
         // Withdraw tokens from the parent treasury into the parent DAO
         data.targets.push(treasuryModuleContract.address);
-        data.values.push(0);
+        data.values.push(BigNumber.from('0'));
         data.calldatas.push(
           TreasuryModule__factory.createInterface().encodeFunctionData('withdrawERC721Tokens', [
             daoData.nftsToFund.map(erc721Fund => erc721Fund.asset.contractAddress),
@@ -177,7 +177,7 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
 
         // Deposit tokens from the parent DAO into the child treasury
         data.targets.push(newDAOData.predictedTreasuryAddress);
-        data.values.push(0);
+        data.values.push(BigNumber.from('0'));
         data.calldatas.push(
           TreasuryModule__factory.createInterface().encodeFunctionData('depositERC721Tokens', [
             daoData.nftsToFund.map(erc721Fund => erc721Fund.asset.contractAddress),
@@ -220,7 +220,7 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
 
       const data: ExecuteData = {
         targets: [metaFactoryContract.address],
-        values: [0],
+        values: [BigNumber.from('0')],
         calldatas: [
           metaFactoryContract.interface.encodeFunctionData('createDAOAndExecute', [
             newDAOData.calldata.daoFactory,

--- a/src/controller/Modules/TokenGovernanceInjector.tsx
+++ b/src/controller/Modules/TokenGovernanceInjector.tsx
@@ -1,14 +1,19 @@
 import { ethers } from 'ethers';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   ERC20__factory,
   TreasuryModule__factory,
   ERC721__factory,
 } from '../../assets/typechain-types/module-treasury';
-import { GovernanceTypes, TokenGovernanceDAO } from '../../components/DaoCreator/provider/types';
+import {
+  GnosisDAO,
+  GovernanceTypes,
+  TokenGovernanceDAO,
+} from '../../components/DaoCreator/provider/types';
 import { useBlockchainData } from '../../contexts/blockchainData';
 import useCreateDAODataCreator from '../../hooks/useCreateDAODataCreator';
+import useCreateGnosisDAODataCreator from '../../hooks/useCreateGnosisDAODataCreator';
 import { useFractal } from '../../providers/fractal/hooks/useFractal';
 import { useGovenorModule } from '../../providers/govenor/hooks/useGovenorModule';
 import { useUserProposalValidation } from '../../providers/govenor/hooks/useUserProposalValidation';
@@ -34,146 +39,218 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
   const canUserCreateProposal = useUserProposalValidation();
 
   const createDAODataCreator = useCreateDAODataCreator();
+  const createGnosisDAODataCreator = useCreateGnosisDAODataCreator();
 
   const { metaFactoryContract } = useBlockchainData();
   const navigate = useNavigate();
-  const successCallback = () => {
+  const successCallback = useCallback(() => {
     if (!daoAddress || !governorModuleContract) {
       return;
     }
 
     navigate(`/daos/${daoAddress}/modules/${governorModuleContract.address}`);
-  };
+  }, [daoAddress, governorModuleContract, navigate]);
 
-  const createDAOTrigger = (daoData: TokenGovernanceDAO, type: GovernanceTypes) => {
-    // @todo look at optimizing how plugin handles different governance deployments
-    if (
-      !daoAddress ||
-      !treasuryModuleContract ||
-      !votingToken ||
-      type === GovernanceTypes.GNOSIS_SAFE
-    ) {
-      return;
-    }
+  const createTokenVotingDAO = useCallback(
+    (_daoData: TokenGovernanceDAO | GnosisDAO) => {
+      const daoData = _daoData as TokenGovernanceDAO;
+      if (!daoAddress || !treasuryModuleContract || !votingToken) {
+        return;
+      }
 
-    const newDAOData = createDAODataCreator(
-      {
-        creator: daoAddress,
-        ...daoData,
-      },
-      votingToken.votingTokenData.address
-    );
+      const newDAOData = createDAODataCreator(
+        {
+          creator: daoAddress,
+          ...daoData,
+        },
+        votingToken.votingTokenData.address
+      );
 
-    if (!metaFactoryContract || !newDAOData) {
-      return;
-    }
+      if (!metaFactoryContract || !newDAOData) {
+        return;
+      }
 
-    const data: ExecuteData = {
-      targets: [metaFactoryContract.address],
-      values: [0],
-      calldatas: [
-        metaFactoryContract.interface.encodeFunctionData('createDAOAndExecute', [
-          newDAOData.calldata.daoFactory,
-          newDAOData.calldata.createDAOParams,
-          newDAOData.calldata.moduleFactories,
-          newDAOData.calldata.moduleFactoriesBytes,
-          newDAOData.calldata.targets,
-          newDAOData.calldata.values,
-          newDAOData.calldata.calldatas,
-        ]),
-      ],
-    };
+      const data: ExecuteData = {
+        targets: [metaFactoryContract.address],
+        values: [0],
+        calldatas: [
+          metaFactoryContract.interface.encodeFunctionData('createDAOAndExecute', [
+            newDAOData.calldata.daoFactory,
+            newDAOData.calldata.createDAOParams,
+            newDAOData.calldata.moduleFactories,
+            newDAOData.calldata.moduleFactoriesBytes,
+            newDAOData.calldata.targets,
+            newDAOData.calldata.values,
+            newDAOData.calldata.calldatas,
+          ]),
+        ],
+      };
 
-    if (daoData.tokensToFund.length > 0) {
-      daoData.tokensToFund.forEach(tokenToFund => {
-        if (tokenToFund.asset.contractAddress !== ethers.constants.AddressZero) {
-          // ERC20 transfer
-          // Approve the new treasury to transfer tokens from the DAO
-          data.targets.push(tokenToFund.asset.contractAddress);
+      if (daoData.tokensToFund.length > 0) {
+        daoData.tokensToFund.forEach(tokenToFund => {
+          if (tokenToFund.asset.contractAddress !== ethers.constants.AddressZero) {
+            // ERC20 transfer
+            // Approve the new treasury to transfer tokens from the DAO
+            data.targets.push(tokenToFund.asset.contractAddress);
+            data.values.push(0);
+            data.calldatas.push(
+              ERC20__factory.createInterface().encodeFunctionData('approve', [
+                newDAOData.predictedTreasuryAddress,
+                ethers.utils.parseUnits(tokenToFund.amount.toString(), tokenToFund.asset.decimals),
+              ])
+            );
+
+            // Withdraw tokens from the parent treasury into the parent DAO
+            data.targets.push(treasuryModuleContract.address);
+            data.values.push(0);
+            data.calldatas.push(
+              TreasuryModule__factory.createInterface().encodeFunctionData('withdrawERC20Tokens', [
+                [tokenToFund.asset.contractAddress],
+                [daoAddress],
+                [
+                  ethers.utils.parseUnits(
+                    tokenToFund.amount.toString(),
+                    tokenToFund.asset.decimals
+                  ),
+                ],
+              ])
+            );
+
+            // Deposit tokens from the parent DAO into the child treasury
+            data.targets.push(newDAOData.predictedTreasuryAddress);
+            data.values.push(0);
+            data.calldatas.push(
+              TreasuryModule__factory.createInterface().encodeFunctionData('depositERC20Tokens', [
+                [tokenToFund.asset.contractAddress],
+                [daoAddress],
+                [
+                  ethers.utils.parseUnits(
+                    tokenToFund.amount.toString(),
+                    tokenToFund.asset.decimals
+                  ),
+                ],
+              ])
+            );
+          } else {
+            // ETH Transfer
+            // Withdraw ETH from the parent treasury into the parent DAO
+            data.targets.push(treasuryModuleContract.address);
+            data.values.push(0);
+            data.calldatas.push(
+              TreasuryModule__factory.createInterface().encodeFunctionData('withdrawEth', [
+                [newDAOData.predictedTreasuryAddress],
+                [
+                  ethers.utils.parseUnits(
+                    tokenToFund.amount.toString(),
+                    tokenToFund.asset.decimals
+                  ),
+                ],
+              ])
+            );
+          }
+        });
+      }
+
+      if (daoData.nftsToFund.length > 0) {
+        // Approve the new treasury to transfer tokens from the DAO
+        daoData.nftsToFund.forEach(erc721Fund => {
+          data.targets.push(erc721Fund.asset.contractAddress);
           data.values.push(0);
           data.calldatas.push(
-            ERC20__factory.createInterface().encodeFunctionData('approve', [
+            ERC721__factory.createInterface().encodeFunctionData('approve', [
               newDAOData.predictedTreasuryAddress,
-              ethers.utils.parseUnits(tokenToFund.amount.toString(), tokenToFund.asset.decimals),
+              erc721Fund.asset.tokenId,
             ])
           );
+        });
 
-          // Withdraw tokens from the parent treasury into the parent DAO
-          data.targets.push(treasuryModuleContract.address);
-          data.values.push(0);
-          data.calldatas.push(
-            TreasuryModule__factory.createInterface().encodeFunctionData('withdrawERC20Tokens', [
-              [tokenToFund.asset.contractAddress],
-              [daoAddress],
-              [ethers.utils.parseUnits(tokenToFund.amount.toString(), tokenToFund.asset.decimals)],
-            ])
-          );
-
-          // Deposit tokens from the parent DAO into the child treasury
-          data.targets.push(newDAOData.predictedTreasuryAddress);
-          data.values.push(0);
-          data.calldatas.push(
-            TreasuryModule__factory.createInterface().encodeFunctionData('depositERC20Tokens', [
-              [tokenToFund.asset.contractAddress],
-              [daoAddress],
-              [ethers.utils.parseUnits(tokenToFund.amount.toString(), tokenToFund.asset.decimals)],
-            ])
-          );
-        } else {
-          // ETH Transfer
-          // Withdraw ETH from the parent treasury into the parent DAO
-          data.targets.push(treasuryModuleContract.address);
-          data.values.push(0);
-          data.calldatas.push(
-            TreasuryModule__factory.createInterface().encodeFunctionData('withdrawEth', [
-              [newDAOData.predictedTreasuryAddress],
-              [ethers.utils.parseUnits(tokenToFund.amount.toString(), tokenToFund.asset.decimals)],
-            ])
-          );
-        }
-      });
-    }
-
-    if (daoData.nftsToFund.length > 0) {
-      // Approve the new treasury to transfer tokens from the DAO
-      daoData.nftsToFund.forEach(erc721Fund => {
-        data.targets.push(erc721Fund.asset.contractAddress);
+        // Withdraw tokens from the parent treasury into the parent DAO
+        data.targets.push(treasuryModuleContract.address);
         data.values.push(0);
         data.calldatas.push(
-          ERC721__factory.createInterface().encodeFunctionData('approve', [
-            newDAOData.predictedTreasuryAddress,
-            erc721Fund.asset.tokenId,
+          TreasuryModule__factory.createInterface().encodeFunctionData('withdrawERC721Tokens', [
+            daoData.nftsToFund.map(erc721Fund => erc721Fund.asset.contractAddress),
+            new Array(daoData.nftsToFund.length).fill(daoAddress),
+            daoData.nftsToFund.map(erc721Fund => erc721Fund.asset.tokenId),
           ])
         );
+
+        // Deposit tokens from the parent DAO into the child treasury
+        data.targets.push(newDAOData.predictedTreasuryAddress);
+        data.values.push(0);
+        data.calldatas.push(
+          TreasuryModule__factory.createInterface().encodeFunctionData('depositERC721Tokens', [
+            daoData.nftsToFund.map(erc721Fund => erc721Fund.asset.contractAddress),
+            new Array(daoData.nftsToFund.length).fill(daoAddress),
+            daoData.nftsToFund.map(erc721Fund => erc721Fund.asset.tokenId),
+          ])
+        );
+      }
+      submitProposal({
+        proposalData: { ...data, description: `New subDAO: ${daoData.daoName}` },
+        successCallback,
+      });
+    },
+    [
+      submitProposal,
+      createDAODataCreator,
+      metaFactoryContract,
+      daoAddress,
+      successCallback,
+      treasuryModuleContract,
+      votingToken,
+    ]
+  );
+
+  const createGnosisDAO = useCallback(
+    (_daoData: TokenGovernanceDAO | GnosisDAO) => {
+      const daoData = _daoData as GnosisDAO;
+      if (!daoAddress) {
+        return;
+      }
+
+      const newDAOData = createGnosisDAODataCreator({
+        creator: daoAddress,
+        ...daoData,
       });
 
-      // Withdraw tokens from the parent treasury into the parent DAO
-      data.targets.push(treasuryModuleContract.address);
-      data.values.push(0);
-      data.calldatas.push(
-        TreasuryModule__factory.createInterface().encodeFunctionData('withdrawERC721Tokens', [
-          daoData.nftsToFund.map(erc721Fund => erc721Fund.asset.contractAddress),
-          new Array(daoData.nftsToFund.length).fill(daoAddress),
-          daoData.nftsToFund.map(erc721Fund => erc721Fund.asset.tokenId),
-        ])
-      );
+      if (!metaFactoryContract || !newDAOData) {
+        return;
+      }
 
-      // Deposit tokens from the parent DAO into the child treasury
-      data.targets.push(newDAOData.predictedTreasuryAddress);
-      data.values.push(0);
-      data.calldatas.push(
-        TreasuryModule__factory.createInterface().encodeFunctionData('depositERC721Tokens', [
-          daoData.nftsToFund.map(erc721Fund => erc721Fund.asset.contractAddress),
-          new Array(daoData.nftsToFund.length).fill(daoAddress),
-          daoData.nftsToFund.map(erc721Fund => erc721Fund.asset.tokenId),
-        ])
-      );
+      const data: ExecuteData = {
+        targets: [metaFactoryContract.address],
+        values: [0],
+        calldatas: [
+          metaFactoryContract.interface.encodeFunctionData('createDAOAndExecute', [
+            newDAOData.calldata.daoFactory,
+            newDAOData.calldata.createDAOParams,
+            newDAOData.calldata.moduleFactories,
+            newDAOData.calldata.moduleFactoriesBytes,
+            newDAOData.calldata.targets,
+            newDAOData.calldata.values,
+            newDAOData.calldata.calldatas,
+          ]),
+        ],
+      };
+
+      submitProposal({
+        proposalData: { ...data, description: `New subDAO: ${daoData.daoName}` },
+        successCallback,
+      });
+    },
+    [submitProposal, createGnosisDAODataCreator, metaFactoryContract, daoAddress, successCallback]
+  );
+
+  const createDAOTrigger = (daoData: TokenGovernanceDAO | GnosisDAO) => {
+    switch (daoData.governance) {
+      case GovernanceTypes.TOKEN_VOTING_GOVERNANCE:
+        return createTokenVotingDAO(daoData);
+      case GovernanceTypes.GNOSIS_SAFE:
+        return createGnosisDAO(daoData);
     }
-    submitProposal({
-      proposalData: { ...data, description: `New subDAO: ${daoData.daoName}` },
-      successCallback,
-    });
   };
+
   if (!governorModuleContract) {
     return null;
   }

--- a/src/controller/Modules/TokenGovernanceInjector.tsx
+++ b/src/controller/Modules/TokenGovernanceInjector.tsx
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -86,7 +86,7 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
         ],
       };
 
-      if (daoData.tokensToFund.length > 0) {
+      if (!!daoData.tokensToFund.length) {
         daoData.tokensToFund.forEach(tokenToFund => {
           if (tokenToFund.asset.contractAddress !== ethers.constants.AddressZero) {
             // ERC20 transfer
@@ -118,7 +118,7 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
 
             // Deposit tokens from the parent DAO into the child treasury
             data.targets.push(newDAOData.predictedTreasuryAddress);
-            data.values.push(0);
+            data.values.push(BigNumber.from(0));
             data.calldatas.push(
               TreasuryModule__factory.createInterface().encodeFunctionData('depositERC20Tokens', [
                 [tokenToFund.asset.contractAddress],
@@ -151,7 +151,7 @@ export function GovernanceInjector({ children }: { children: JSX.Element }) {
         });
       }
 
-      if (daoData.nftsToFund.length > 0) {
+      if (!!daoData.nftsToFund.length) {
         // Approve the new treasury to transfer tokens from the DAO
         daoData.nftsToFund.forEach(erc721Fund => {
           data.targets.push(erc721Fund.asset.contractAddress);


### PR DESCRIPTION
PR changes one file - TokenGovernanceInjector.

The intent of this PR is to provide the user with the ability to propose a gnosis / token voting sub DAO. This is accomplished by utilising cases to determine if the proposal should include the gnosis or token voting encoded data.

Things to note: The 1:1 token voting does not work due to a small bug which has been addressed in #453 - the bug will be fixed during the merge.

To test this PR - please try to create a gnosis Safe subdao