### PR TITLE
replaces react.closeElement with context provider

### DIFF
--- a/src/controller/Modules/GovernanceController.tsx
+++ b/src/controller/Modules/GovernanceController.tsx
@@ -53,7 +53,7 @@ export function GovernanceController({ children }: { children: JSX.Element }) {
         </GnosisWrapperProvider>
       );
     default: {
-      return children;
+      return null;
     }
   }
 }

--- a/src/controller/Modules/injectors/GnosisGovernanceInjector.tsx
+++ b/src/controller/Modules/injectors/GnosisGovernanceInjector.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   GnosisDAO,
   GovernanceTypes,
@@ -22,6 +22,7 @@ import { GnosisTransaction, GnosisTransactionAPI } from '../../../providers/gnos
 import useCreateDAODataCreator from '../../../hooks/useCreateDAODataCreator';
 import { toast } from 'react-toastify';
 import { useNavigate } from 'react-router-dom';
+import { InjectorContext } from './GovernanceInjectorConext';
 
 export function GnosisGovernanceInjector({ children }: { children: JSX.Element }) {
   const {
@@ -190,14 +191,15 @@ export function GnosisGovernanceInjector({ children }: { children: JSX.Element }
     ]
   );
 
-  const createDAOTrigger = (daoData: TokenGovernanceDAO | GnosisDAO) => {
-    createDAO(daoData);
-  };
+  const value = useMemo(
+    () => ({
+      createDAOTrigger: createDAO,
+      createProposal: () => {},
+      pending: pending,
+      isAuthorized: isSigner,
+    }),
+    [createDAO, pending, isSigner]
+  );
 
-  return React.cloneElement(children, {
-    createDAOTrigger,
-    createProposal: () => {},
-    pending: pending,
-    isAuthorized: isSigner,
-  });
+  return <InjectorContext.Provider value={value}>{children}</InjectorContext.Provider>;
 }

--- a/src/controller/Modules/injectors/GovernanceInjectorConext.tsx
+++ b/src/controller/Modules/injectors/GovernanceInjectorConext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import { DAOTrigger } from '../../../components/DaoCreator/provider/types';
+import { ProposalExecuteData } from '../../../types/proposal';
+
+export interface IInjectorContext {
+  createProposal?: (proposal: {
+    proposalData: ProposalExecuteData;
+    successCallback: () => void;
+  }) => void;
+  pending?: boolean;
+  isAuthorized?: boolean;
+  createDAOTrigger: DAOTrigger;
+}
+
+export const InjectorContext = createContext<IInjectorContext | null>(null);
+
+export const useInjector = (): IInjectorContext =>
+  useContext(InjectorContext as React.Context<IInjectorContext>);

--- a/src/pages/Transactions/Fractalize/index.tsx
+++ b/src/pages/Transactions/Fractalize/index.tsx
@@ -1,12 +1,8 @@
 import DaoCreator from '../../../components/DaoCreator';
-import { DAOTrigger } from '../../../components/DaoCreator/provider/types';
+import { useInjector } from '../../../controller/Modules/injectors/GovernanceInjectorConext';
 
-import { GovernanceProposalData } from '../../../controller/Modules/types';
-interface IFractalize extends GovernanceProposalData {
-  createDAOTrigger?: DAOTrigger;
-}
-
-function Fractalize({ createDAOTrigger, pending }: IFractalize) {
+function Fractalize() {
+  const { pending, createDAOTrigger } = useInjector();
   return (
     <DaoCreator
       pending={pending}

--- a/src/pages/Transactions/Plugins.tsx
+++ b/src/pages/Transactions/Plugins.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import Fractalize from './Fractalize';
 import { PrimaryButton, SecondaryButton } from '../../components/ui/forms/Button';
-import { GovernanceProposalData } from '../../controller/Modules/types';
-import { DAOTrigger } from '../../components/DaoCreator/provider/types';
+import { useInjector } from '../../controller/Modules/injectors/GovernanceInjectorConext';
 
 enum View {
   Cards,
@@ -38,18 +37,15 @@ function CardDetails({
   );
 }
 
-interface IPlugins extends GovernanceProposalData {
-  createDAOTrigger?: DAOTrigger;
-}
-
-function Plugins(props: IPlugins) {
+function Plugins() {
   const [view, setView] = useState(View.Cards);
+  const { isAuthorized } = useInjector();
 
   switch (view) {
     case View.CreateDAO: {
       return (
         <CardDetails setView={setView}>
-          <Fractalize {...props} />
+          <Fractalize />
         </CardDetails>
       );
     }
@@ -59,7 +55,7 @@ function Plugins(props: IPlugins) {
         <div className="flex flex-wrap">
           <CreateDAOCard
             onClick={() => setView(View.CreateDAO)}
-            disabled={!props.isAuthorized}
+            disabled={!isAuthorized}
           />
         </div>
       );


### PR DESCRIPTION
## Description

The objective of this PR is to prepare for removing subsidiary funding dependency on the treasury module hook. The first step here is to change the injector to return a context provider component. This will allow for the children of the injector to use the injector hook `useInjector` to access these props

## Notes
n/a

## Issue (if applicable)
Issue will be attached to next PR

## Testing
There is really no visual or feature change with this PR. As long as there isn't any weird errors when the Transaction page loads it  should be good to go.
- Transactions Page still loads correctly
- (Extra) tested that plugin still works as expected.

## Screenshots (if applicable)
n/a