### PR TITLE
Implement showing transaction events for classic Treasury

### DIFF
--- a/src/components/Dao/Dashboard.tsx
+++ b/src/components/Dao/Dashboard.tsx
@@ -29,8 +29,10 @@ function Dashboard({ transactions }: DashboardProps) {
         <ContentBox key={transaction.transactionHash}>
           <ContentBoxTitle>
             {transaction.eventType === TokenEventType.DEPOSIT ? 'Received' : 'Sent'}{' '}
-            {transaction.amount ||
-              transaction.amounts?.map((amount: BigNumber) => amount.toString())}
+            {transaction.amount?.toString
+              ? transaction.amount.toString()
+              : transaction.amount ||
+                transaction.amounts?.map((amount: BigNumber) => amount.toString())}
           </ContentBoxTitle>
           <EtherscanTransactionLink txHash={transaction.transactionHash}>
             View on Etherscan

--- a/src/components/Dao/Dashboard.tsx
+++ b/src/components/Dao/Dashboard.tsx
@@ -1,6 +1,44 @@
+import {
+  TokenDepositEvent,
+  TokenWithdrawEvent,
+  ERC20TokenEvent,
+  ERC721TokenEvent,
+  TokenEventType,
+} from '../../providers/treasury/types';
+import { useFractal } from '../../providers/fractal/hooks/useFractal';
+import ContentBox from '../ui/ContentBox';
+import ContentBoxTitle from '../ui/ContentBoxTitle';
+import H1 from '../ui/H1';
+import EtherscanTransactionLink from '../ui/EtherscanTransactionLink';
+import { BigNumber } from 'ethers';
+
 // This component should replace Summary, but for development purpose - it is kept alongside
-function DaoDashboard() {
-  return <div>Hello there :)</div>;
+type DashboardProps = {
+  transactions?: (TokenDepositEvent | TokenWithdrawEvent | ERC20TokenEvent | ERC721TokenEvent)[];
+};
+function Dashboard({ transactions }: DashboardProps) {
+  const { dao } = useFractal();
+
+  return (
+    <div>
+      <ContentBox>
+        <H1>{dao.daoName}</H1>
+      </ContentBox>
+      <H1>Latest Activity</H1>
+      {transactions?.map((transaction: any) => (
+        <ContentBox key={transaction.transactionHash}>
+          <ContentBoxTitle>
+            {transaction.eventType === TokenEventType.DEPOSIT ? 'Received' : 'Sent'}{' '}
+            {transaction.amount ||
+              transaction.amounts?.map((amount: BigNumber) => amount.toString())}
+          </ContentBoxTitle>
+          <EtherscanTransactionLink address={transaction.transactionhas}>
+            View on Etherscan
+          </EtherscanTransactionLink>
+        </ContentBox>
+      ))}
+    </div>
+  );
 }
 
-export default DaoDashboard;
+export default Dashboard;

--- a/src/components/Dao/Dashboard.tsx
+++ b/src/components/Dao/Dashboard.tsx
@@ -32,7 +32,7 @@ function Dashboard({ transactions }: DashboardProps) {
             {transaction.amount ||
               transaction.amounts?.map((amount: BigNumber) => amount.toString())}
           </ContentBoxTitle>
-          <EtherscanTransactionLink address={transaction.transactionhas}>
+          <EtherscanTransactionLink txHash={transaction.transactionHash}>
             View on Etherscan
           </EtherscanTransactionLink>
         </ContentBox>

--- a/src/components/ui/EtherscanTransactionLink.tsx
+++ b/src/components/ui/EtherscanTransactionLink.tsx
@@ -10,7 +10,7 @@ function EtherscanTransactionLink({
   const subdomain = useSubDomain();
   return (
     <a
-      href={`https://${subdomain}etherscan.io/transaction/${address}`}
+      href={`https://${subdomain}etherscan.io/tx/${address}`}
       target="_blank"
       rel="noreferrer"
     >

--- a/src/components/ui/EtherscanTransactionLink.tsx
+++ b/src/components/ui/EtherscanTransactionLink.tsx
@@ -1,0 +1,22 @@
+import useSubDomain from '../../hooks/useSubDomain';
+
+function EtherscanTransactionLink({
+  address,
+  children,
+}: {
+  address: string | undefined;
+  children: React.ReactNode;
+}) {
+  const subdomain = useSubDomain();
+  return (
+    <a
+      href={`https://${subdomain}etherscan.io/transaction/${address}`}
+      target="_blank"
+      rel="noreferrer"
+    >
+      {children}
+    </a>
+  );
+}
+
+export default EtherscanTransactionLink;

--- a/src/components/ui/EtherscanTransactionLink.tsx
+++ b/src/components/ui/EtherscanTransactionLink.tsx
@@ -1,16 +1,16 @@
 import useSubDomain from '../../hooks/useSubDomain';
 
 function EtherscanTransactionLink({
-  address,
+  txHash,
   children,
 }: {
-  address: string | undefined;
+  txHash: string | undefined;
   children: React.ReactNode;
 }) {
   const subdomain = useSubDomain();
   return (
     <a
-      href={`https://${subdomain}etherscan.io/tx/${address}`}
+      href={`https://${subdomain}etherscan.io/tx/${txHash}`}
       target="_blank"
       rel="noreferrer"
     >

--- a/src/controller/Modules/TreasuryController.tsx
+++ b/src/controller/Modules/TreasuryController.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, PropsWithChildren } from 'react';
+import { useState, useEffect } from 'react';
 import { useFractal } from '../../providers/fractal/hooks/useFractal';
 import { TreasuryModuleProvider } from '../../providers/treasury/TreasuryModuleProvider';
 import { GnosisWrapperProvider } from '../../providers/gnosis/GnosisWrapperProvider';
@@ -6,7 +6,7 @@ import { TreasuryInjector } from './injectors/TreasuryInjector';
 import { GnosisTreasuryInjector } from './injectors/GnosisTreasuryInjector';
 import { ModuleTypes } from './types';
 
-export function TreasuryController({ children }: PropsWithChildren) {
+export function TreasuryController({ children }: { children: JSX.Element }) {
   const {
     modules: { treasuryModule, gnosisWrapperModule },
   } = useFractal();
@@ -37,7 +37,7 @@ export function TreasuryController({ children }: PropsWithChildren) {
       );
     }
     default: {
-      return <>{children}</>;
+      return children;
     }
   }
 }

--- a/src/controller/Modules/injectors/GnosisTreasuryInjector.tsx
+++ b/src/controller/Modules/injectors/GnosisTreasuryInjector.tsx
@@ -1,6 +1,15 @@
-import { PropsWithChildren } from 'react';
+import { cloneElement } from 'react';
+import useGnosisEvents from '../../../providers/gnosis/hooks/useGnosisEvents';
+import { useGnosisWrapper } from '../../../providers/gnosis/hooks/useGnosisWrapper';
+import useGnosisWrapperContract from '../../../providers/gnosis/hooks/useGnosisWrapperContract';
 
-export function GnosisTreasuryInjector({ children }: PropsWithChildren) {
-  // TODO: Inject Gnosis-specific treasury data
-  return <div>{children}</div>;
+export function GnosisTreasuryInjector({ children }: { children: JSX.Element }) {
+  const { state } = useGnosisWrapper();
+  const gnosisWrapperContract = useGnosisWrapperContract(state.safeAddress!);
+  const { events } = useGnosisEvents(gnosisWrapperContract);
+
+  // TODO: Pass events in more modular way
+  return cloneElement(children, {
+    transactions: events,
+  });
 }

--- a/src/controller/Modules/injectors/TreasuryInjector.tsx
+++ b/src/controller/Modules/injectors/TreasuryInjector.tsx
@@ -1,6 +1,32 @@
-import { PropsWithChildren } from 'react';
+import { cloneElement } from 'react';
+import { useTreasuryModule } from '../../../providers/treasury/hooks/useTreasuryModule';
+import useTreasuryEvents from '../../../providers/treasury/hooks/useTreasuryEvents';
 
-export function TreasuryInjector({ children }: PropsWithChildren) {
-  // TODO: return treasury data
-  return <div>{children}</div>;
+// TODO: At least it makes sense to refactor TreasuryInjector and GovernanceInjector to HOCs
+// That will look way more "React.js-way", as current Injector pattern looks more like from Angular :D
+// However, need discussion for this during PR review
+export function TreasuryInjector({ children }: { children: JSX.Element }) {
+  const { treasuryModuleContract, treasuryAssetsFungible, treasuryAssetsNonFungible } =
+    useTreasuryModule();
+  const {
+    nativeDeposits,
+    nativeWithdraws,
+    erc20TokenDeposits,
+    erc20TokenWithdraws,
+    erc721TokenDeposits,
+    erc721TokenWithdraws,
+  } = useTreasuryEvents(treasuryModuleContract);
+
+  return cloneElement(children, {
+    transactions: [
+      ...(nativeDeposits || []),
+      ...nativeWithdraws,
+      ...erc20TokenDeposits,
+      ...erc20TokenWithdraws,
+      ...erc721TokenDeposits,
+      ...erc721TokenWithdraws,
+    ],
+    treasuryAssetsFungible,
+    treasuryAssetsNonFungible,
+  });
 }

--- a/src/pages/Dao/index.tsx
+++ b/src/pages/Dao/index.tsx
@@ -8,6 +8,7 @@ import { Modules } from '../../controller/Modules';
 import Transactions from '../Transactions';
 import { useFractal } from '../../providers/fractal/hooks/useFractal';
 import { TreasuryController } from '../../controller/Modules/TreasuryController';
+import { GovernanceController } from '../../controller/Modules/GovernanceController';
 
 function DAORoutes() {
   return (
@@ -19,9 +20,11 @@ function DAORoutes() {
       <Route
         path="dashboard/*"
         element={
-          <TreasuryController>
-            <Dashboard />
-          </TreasuryController>
+          <GovernanceController>
+            <TreasuryController>
+              <Dashboard />
+            </TreasuryController>
+          </GovernanceController>
         }
       />
       <Route

--- a/src/providers/gnosis/hooks/useGnosisEvents.ts
+++ b/src/providers/gnosis/hooks/useGnosisEvents.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect, useCallback } from 'react';
+import { GnosisWrapper } from '../../../assets/typechain-types/gnosis-wrapper';
+
+const useGnosisEvents = (gnosisWrapperContract?: GnosisWrapper) => {
+  // TODO: Get Transaction & Proposal events, make this hook more modular - just as useTreasuryEvents
+  const [allEvents, setAllEvents] = useState<any>([]);
+
+  const getPastEvents = useCallback(
+    async (filter: any) => {
+      if (gnosisWrapperContract) {
+        const events = await gnosisWrapperContract.queryFilter(filter);
+        return events;
+      }
+      return [];
+    },
+    [gnosisWrapperContract]
+  );
+
+  useEffect(() => {
+    const getData = async () => {
+      if (gnosisWrapperContract) {
+        const events = await getPastEvents(gnosisWrapperContract.filters);
+        setAllEvents(events);
+      }
+    };
+    getData();
+  }, [gnosisWrapperContract, getPastEvents]);
+  return {
+    events: allEvents,
+  };
+};
+
+export default useGnosisEvents;

--- a/src/providers/treasury/types/index.ts
+++ b/src/providers/treasury/types/index.ts
@@ -11,11 +11,6 @@ export interface TokenEvent {
   eventType: TokenEventType;
 }
 
-export enum TokenEventType {
-  DEPOSIT = 'DEPOSIT',
-  WITHDRAW = 'WITHDRAW',
-}
-
 export interface TokenDepositEvent extends TokenEvent {
   address: string;
   amount: BigNumber;

--- a/src/providers/treasury/types/index.ts
+++ b/src/providers/treasury/types/index.ts
@@ -11,6 +11,11 @@ export interface TokenEvent {
   eventType: TokenEventType;
 }
 
+export enum TokenEventType {
+  DEPOSIT = 'DEPOSIT',
+  WITHDRAW = 'WITHDRAW',
+}
+
 export interface TokenDepositEvent extends TokenEvent {
   address: string;
   amount: BigNumber;


### PR DESCRIPTION
## Description

As part of Activity Feed implementation - this PR scoped to enhancing `TreasuryController` and showing list of transaction events.

## Notes

Next PR supposed to make same for Gnosis Safe Treasury-based DAO, so while making code review - mind that this PR is focusing "1:1" Treasury, but also enhances general boilerplate

## Issue
Closes #486 

<!-- If applicable, link to the relevant issue(s) with `closes #XXX` to auto-close it when this PR is merged -->

## Testing

1. Visit DAO dashboard page that has 1:1 Token Governance (therefore "classic" Treasury) - example link http://localhost:3000/#/daos/0x68dB43B90E6284019c0513168b514d103F4e1092/dashboard
2. Observe transactions appearing there
3. Optional, if the DAO don't have much transactions in history - try to send tokens / NFTs / native token to the DAO, try to withdraw funds from there (not sure there's a way for that currently though 🤷🏼 )

## Screenshots (if applicable)
<img width="853" alt="Знімок екрана 2022-09-12 о 18 04 48" src="https://user-images.githubusercontent.com/25801162/189690780-a3579d0c-a4d2-4b02-a5b0-fb4118b909d6.png">
