### PR TITLE
Playwright setup cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.30.1",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "playwright": "^1.26.0",
         "postcss": "^8.4.16",
         "prettier": "^2.7.1",
         "react-app-rewired": "^2.2.1",
@@ -3985,13 +3986,13 @@
       "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@playwright/test": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.25.2.tgz",
-      "integrity": "sha512-6qPznIR4Fw02OMbqXUPMG6bFFg1hDVNEdihKy0t9K0dmRbus1DyP5Q5XFQhGwEHQkLG5hrSfBuu9CW/foqhQHQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.0.tgz",
+      "integrity": "sha512-D24pu1k/gQw3Lhbpc38G5bXlBjGDrH5A52MsrH12wz6ohGDeQ+aZg/JFSEsT/B3G8zlJe/EU4EkJK74hpqsjEg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.25.2"
+        "playwright-core": "1.26.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13826,10 +13827,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.26.0.tgz",
+      "integrity": "sha512-XxTVlvFEYHdatxUkh1KiPq9BclNtFKMi3BgQnl/aactmhN4G9AkZUXwt0ck6NDAOrDFlfibhbM7A1kZwQJKSBw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.26.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/playwright-core": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.2.tgz",
-      "integrity": "sha512-0yTbUE9lIddkEpLHL3u8PoCL+pWiZtj5A/j3U7YoNjcmKKDGBnCrgHJMzwd2J5vy6l28q4ki3JIuz7McLHhl1A==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.0.tgz",
+      "integrity": "sha512-p8huU8eU4gD3VkJd3DA1nA7R3XA6rFvFL+1RYS96cSljCF2yJE9CWEHTPF4LqX8KN9MoWCrAfVKP5381X3CZqg==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -21326,13 +21343,13 @@
       "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "@playwright/test": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.25.2.tgz",
-      "integrity": "sha512-6qPznIR4Fw02OMbqXUPMG6bFFg1hDVNEdihKy0t9K0dmRbus1DyP5Q5XFQhGwEHQkLG5hrSfBuu9CW/foqhQHQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.0.tgz",
+      "integrity": "sha512-D24pu1k/gQw3Lhbpc38G5bXlBjGDrH5A52MsrH12wz6ohGDeQ+aZg/JFSEsT/B3G8zlJe/EU4EkJK74hpqsjEg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.25.2"
+        "playwright-core": "1.26.0"
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -28735,10 +28752,19 @@
         }
       }
     },
+    "playwright": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.26.0.tgz",
+      "integrity": "sha512-XxTVlvFEYHdatxUkh1KiPq9BclNtFKMi3BgQnl/aactmhN4G9AkZUXwt0ck6NDAOrDFlfibhbM7A1kZwQJKSBw==",
+      "dev": true,
+      "requires": {
+        "playwright-core": "1.26.0"
+      }
+    },
     "playwright-core": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.2.tgz",
-      "integrity": "sha512-0yTbUE9lIddkEpLHL3u8PoCL+pWiZtj5A/j3U7YoNjcmKKDGBnCrgHJMzwd2J5vy6l28q4ki3JIuz7McLHhl1A==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.0.tgz",
+      "integrity": "sha512-p8huU8eU4gD3VkJd3DA1nA7R3XA6rFvFL+1RYS96cSljCF2yJE9CWEHTPF4LqX8KN9MoWCrAfVKP5381X3CZqg==",
       "dev": true
     },
     "pngjs": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "^1.25.2",
+    "@playwright/test": "^1.26.0",
     "@typescript-eslint/eslint-plugin": "^5.34.0",
     "@typescript-eslint/parser": "^5.34.0",
     "autoprefixer": "^10.4.8",
@@ -70,6 +70,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "playwright": "^1.26.0",
     "postcss": "^8.4.16",
     "prettier": "^2.7.1",
     "react-app-rewired": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "dependencies": {
     "@fractal-framework/core-contracts": "^0.1.9",
     "@headlessui/react": "^1.6.6",
-    "@tanstack/react-query": "^4.2.3",
     "@sentry/react": "^7.11.1",
     "@sentry/tracing": "^7.11.1",
+    "@tanstack/react-query": "^4.2.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.4.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build:windows": "for /F \"delims=\" %I in ('git rev-parse HEAD') do set \"REACT_APP_GIT_HASH=%I\" && react-app-rewired build",
     "test": "REACT_APP_GIT_HASH=`git rev-parse HEAD` react-app-rewired test",
     "eject": "react-app-rewired eject",
-    "tests:chrome": "playwright test --config=playwright.config.ts --project=Chromium"
+    "tests": "playwright test --project=chromium --project=firefox"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Description

Slight updates to the Playwright config setup including:

- adding `playwright` as a dev dependency, which makes it so that we don't have to separately do `npx playwright install` after `npm install` to get the correct browsers installed.
- updates the run script to target both chromium and firefox, and doesn't explicitly say to use the default config file (it just uses it by default)

## Notes

n/a

## Issue (if applicable)

n/a

## Testing

n/a

## Screenshots (if applicable)

n/a
