### PR TITLE
V1 Design | Header Depth and Wallet Menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ function App() {
           bg="chocolate.900"
           h="4rem"
           position="fixed"
+          zIndex="sticky"
           w="calc(100% - 4.25rem)"
         >
           <Header />

--- a/src/components/menus/AccountDisplay/MenuItemButton.tsx
+++ b/src/components/menus/AccountDisplay/MenuItemButton.tsx
@@ -20,7 +20,7 @@ export function MenuItemButton({
     <Fragment>
       <MenuItem
         cursor="pointer"
-        p="4"
+        p="1rem 1.5rem"
         data-testid={testId}
         onClick={onClick}
         border="1px solid"
@@ -35,7 +35,7 @@ export function MenuItemButton({
           w="full"
         >
           <Text textStyle="text-base-mono-medium">{label}</Text>
-          <Icon />
+          <Icon boxSize="1.5rem" />
         </Flex>
       </MenuItem>
     </Fragment>

--- a/src/components/menus/AccountDisplay/MenuItemNetwork.tsx
+++ b/src/components/menus/AccountDisplay/MenuItemNetwork.tsx
@@ -17,7 +17,7 @@ export function MenuItemNetwork() {
     <MenuItem
       data-testid="accountMenu-network"
       cursor="default"
-      p="4"
+      p="1rem 1.5rem"
     >
       <Flex
         direction="column"
@@ -34,8 +34,8 @@ export function MenuItemNetwork() {
           gap="2"
         >
           <Box
-            w="4"
-            h="4"
+            w="1rem"
+            h="1rem"
             bg={color}
             rounded="full"
           ></Box>

--- a/src/components/menus/AccountDisplay/MenuItemWallet.tsx
+++ b/src/components/menus/AccountDisplay/MenuItemWallet.tsx
@@ -28,7 +28,7 @@ export function MenuItemWallet() {
       data-testid="accountMenu-wallet"
       bg="black.900"
       cursor="default"
-      p="4"
+      p="1rem 1.5rem"
       borderBottomRadius="lg"
     >
       <Flex

--- a/src/components/menus/AccountDisplay/MenuItems.tsx
+++ b/src/components/menus/AccountDisplay/MenuItems.tsx
@@ -13,10 +13,10 @@ export function MenuItems() {
   } = useWeb3Provider();
   return (
     <MenuList
-      w="14rem"
+      w="16.25rem"
       rounded="lg"
       shadow={'0px 0px 48px rgba(250, 189, 46, 0.48)'}
-      mr={['auto', '2rem']}
+      mr={['auto', '1rem']}
       className="menu-list"
       bg="grayscale.black"
       sx={{


### PR DESCRIPTION
## Description
Quick bug fix. Noticed that the menu was being rendered behind some content on the page. Added 'sticky' zIndex. which is a chakra-ui key for 1100.

<!-- Please describe your changes -->

## Notes

I also went ahead and updated the styling of the wallet menu. noticed the width and padding was quite off as I was creating a screenshot for the quick fix.

## Issue / Notion doc (if applicable)

<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #XXX` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.

New feature work should include a correlating automated integration test via Playwright, in collaboration with the QA team. See this repo's README.md for Playwright setup.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/38386583/197371331-2c53d154-c211-412b-8038-a3bc57b63af6.png)
