### PR TITLE
Treasury bug

### DIFF
--- a/src/components/ui/Sidebar/index.tsx
+++ b/src/components/ui/Sidebar/index.tsx
@@ -138,7 +138,7 @@ function Sidebar() {
         gap="2rem"
         mb="8"
       >
-        <SidebarTooltipWrapper label={t('support')}>
+        <SidebarTooltipWrapper label={t('faq')}>
           <a
             data-testid="sidebarExternal-support"
             href={URL_FAQ}

--- a/src/i18n/locales/en/sidebar.json
+++ b/src/i18n/locales/en/sidebar.json
@@ -3,7 +3,7 @@
   "proposals": "Proposals",
   "nodes": "Nodes",
   "treasury": "Treasury",
-  "support": "Support",
+  "faq": "FAQ",
   "documentation": "Documentation",
   "ariaLabelFractalBrand": "Navigate Fractal Home",
   "ariaLabelHome": "Navigate DAO Home",

--- a/src/pages/Treasury/hooks/useFormatCoins.tsx
+++ b/src/pages/Treasury/hooks/useFormatCoins.tsx
@@ -16,11 +16,12 @@ export interface TokenDisplayData {
 
 export function useFormatCoins(assets: GnosisAssetFungible[]) {
   let totalFiatValue = 0;
-  let displayData: TokenDisplayData[] = new Array(assets.length);
+  let displayData: TokenDisplayData[] = [];
   for (let i = 0; i < assets.length; i++) {
     let asset = assets[i];
     totalFiatValue += Number(asset.fiatBalance);
     let symbol = asset.token === null ? 'ETH' : asset.token.symbol;
+    if (symbol === 'ETH' && asset.balance === '0') continue; // if Eth balance is zero, don't add it to the list
     const formatted: TokenDisplayData = {
       iconUri: asset.token === null ? ethDefault : asset.token.logoUri,
       address: asset.tokenAddress === null ? ethers.constants.AddressZero : asset.tokenAddress,
@@ -36,7 +37,7 @@ export function useFormatCoins(assets: GnosisAssetFungible[]) {
       fullCoinTotal: formatCoin(asset.balance, false, asset?.token?.decimals, asset?.token?.symbol),
       fiatDisplayValue: formatUSD(Number(asset.fiatBalance)),
     };
-    displayData[i] = formatted;
+    displayData.push(formatted);
   }
   displayData.sort((a, b) => b.fiatValue - a.fiatValue); // sort by USD value
   return {


### PR DESCRIPTION
## Description

Fixes a bug where a line for Eth appears in the treasury when there is zero balance.

This is because the Eth asset is returned from the Gnosis API regardless of a zero amount.

## Notes

<!-- Is there any additional information a reviewer should know?  -->

## Issue / Notion doc (if applicable)

Closes https://github.com/decent-dao/fractal-interface/issues/679

## Testing

Create a new DAO and navigate to the treasury.

There should be no line item for $0 Eth in the treasury assets.
