### PR TITLE
precision percentages with BigNumbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "framer-motion": "^6.5.1",
         "i18next": "^21.9.2",
         "i18next-browser-languagedetector": "^6.1.5",
+        "js-big-decimal": "^1.3.12",
         "process": "^0.11.10",
         "react": "^18.2.0",
         "react-app-rewired": "^2.2.1",
@@ -14027,6 +14028,11 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/js-big-decimal": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/js-big-decimal/-/js-big-decimal-1.3.12.tgz",
+      "integrity": "sha512-FWAINnjcRoteTgDC6jqyCXgzLZydrlKXLXvI7GizM7gfprrfmtw7mNdn2x1cO51FCEi5eeKPdQe7QDPKwsOBag=="
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
@@ -30632,6 +30638,11 @@
           }
         }
       }
+    },
+    "js-big-decimal": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/js-big-decimal/-/js-big-decimal-1.3.12.tgz",
+      "integrity": "sha512-FWAINnjcRoteTgDC6jqyCXgzLZydrlKXLXvI7GizM7gfprrfmtw7mNdn2x1cO51FCEi5eeKPdQe7QDPKwsOBag=="
     },
     "js-sha3": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "framer-motion": "^6.5.1",
     "i18next": "^21.9.2",
     "i18next-browser-languagedetector": "^6.1.5",
+    "js-big-decimal": "^1.3.12",
     "process": "^0.11.10",
     "react": "^18.2.0",
     "react-app-rewired": "^2.2.1",

--- a/src/components/Proposals/ProposalVotes.tsx
+++ b/src/components/Proposals/ProposalVotes.tsx
@@ -11,7 +11,7 @@ import { BigNumber } from 'ethers';
 import { useTranslation } from 'react-i18next';
 import useDisplayName from '../../hooks/useDisplayName';
 import { Proposal, ProposalVote } from '../../providers/fractal/types';
-import { formatCoin } from '../../utils/numberFormats';
+import { formatCoin, formatPercentage } from '../../utils/numberFormats';
 import ContentBox from '../ui/ContentBox';
 import ProgressBar from '../ui/ProgressBar';
 import StatusBox from '../ui/StatusBox';
@@ -21,52 +21,52 @@ const MOCK_VOTES: ProposalVote[] = [
   {
     voter: '0x6a0db4cef1ce2a5f81c8e6322862439f71aca29d',
     choice: 'no',
-    weight: BigNumber.from(150),
+    weight: BigNumber.from('150000000000000000000'),
   },
   {
     voter: '0x6a0db4cef1ce2a5f81c8e6322862439f71aca29a',
     choice: 'yes',
-    weight: BigNumber.from(2000),
+    weight: BigNumber.from('2000000000000000000000'),
   },
   {
     voter: '0x6a0db4cef1ce2a5f81c8e6322862439f71aca29b',
     choice: 'yes',
-    weight: BigNumber.from(100),
+    weight: BigNumber.from('100000000000000000000'),
   },
   {
     voter: '0x6a0db4cef1ce2a5f81c8e6322862439f71aca29c',
     choice: 'yes',
-    weight: BigNumber.from(75),
+    weight: BigNumber.from('75000000000000000000'),
   },
   {
     voter: '0x6a0db4cef1ce2a5f81c8e6322862439f71aca29e',
     choice: 'abstain',
-    weight: BigNumber.from(400),
+    weight: BigNumber.from('400000000000000000000'),
   },
   {
     voter: '0x6a0db4cef1ce2a5f81c8e6322862439f71aca29f',
     choice: 'no',
-    weight: BigNumber.from(150),
+    weight: BigNumber.from('150000000000000000000'),
   },
   {
     voter: '0x6a0db4cef1ce2a5f81c8e6322862439f71aca29g',
     choice: 'yes',
-    weight: BigNumber.from(150),
+    weight: BigNumber.from('150000000000000000000'),
   },
   {
     voter: '0x6a0db4cef1ce2a5f81c8e6322862439f71aca29k',
     choice: 'yes',
-    weight: BigNumber.from(150),
+    weight: BigNumber.from('150000000000000000000'),
   },
   {
     voter: '0x6a0db4cef1ce2a5f81c8e6322862439f71aca29l',
     choice: 'yes',
-    weight: BigNumber.from(150),
+    weight: BigNumber.from('150000000000000000000'),
   },
   {
     voter: '0x6a0db4cef1ce2a5f81c8e6322862439f71aca29m',
     choice: 'no',
-    weight: BigNumber.from(150),
+    weight: BigNumber.from('150000000000000000000'),
   },
 ];
 
@@ -90,10 +90,12 @@ function VotesPercentage({ label, percentage }: { label: string; percentage: num
 function ProposalVoteItem({
   vote,
   govTokenTotalSupply,
+  govTokenDecimals,
   govTokenSymbol,
 }: {
   vote: ProposalVote;
   govTokenTotalSupply: BigNumber;
+  govTokenDecimals: number;
   govTokenSymbol: string;
 }) {
   const { t } = useTranslation();
@@ -113,12 +115,12 @@ function ProposalVoteItem({
       </GridItem>
       <GridItem colSpan={1}>
         <Text textStyle="text-base-sans-regular">
-          {vote.weight.div(govTokenTotalSupply).mul(100).toNumber()}%
+          {formatPercentage(vote.weight, govTokenTotalSupply)}
         </Text>
       </GridItem>
       <GridItem colSpan={1}>
         <Text textStyle="text-base-sans-regular">
-          {formatCoin(vote.weight, true, 18, govTokenSymbol)}
+          {formatCoin(vote.weight, false, govTokenDecimals, govTokenSymbol)}
         </Text>
       </GridItem>
     </Grid>
@@ -130,10 +132,12 @@ function ProposalVotes({
     votes: { yes, no, abstain },
   },
   govTokenTotalSupply,
+  govTokenDecimals,
   govTokenSymbol,
 }: {
   proposal: Proposal;
   govTokenTotalSupply: BigNumber;
+  govTokenDecimals: number;
   govTokenSymbol: string;
 }) {
   const { t } = useTranslation(['common', 'proposal']);
@@ -210,6 +214,7 @@ function ProposalVotes({
               key={vote.voter}
               vote={vote}
               govTokenTotalSupply={govTokenTotalSupply}
+              govTokenDecimals={govTokenDecimals}
               govTokenSymbol={govTokenSymbol}
             />
           ))}

--- a/src/components/Proposals/ProposalVotes.tsx
+++ b/src/components/Proposals/ProposalVotes.tsx
@@ -120,7 +120,7 @@ function ProposalVoteItem({
       </GridItem>
       <GridItem colSpan={1}>
         <Text textStyle="text-base-sans-regular">
-          {formatCoin(vote.weight, false, govTokenDecimals, govTokenSymbol)}
+          {formatCoin(vote.weight, true, govTokenDecimals, govTokenSymbol)}
         </Text>
       </GridItem>
     </Grid>

--- a/src/pages/ProposalDetails/index.tsx
+++ b/src/pages/ProposalDetails/index.tsx
@@ -19,7 +19,8 @@ import useProposals from '../../providers/fractal/hooks/useProposals';
 import { Proposal } from '../../providers/fractal/types';
 import { DAO_ROUTES } from '../../routes/constants';
 
-const MOCK_GOV_TOKEN_TOTAL_SUPPLY = BigNumber.from('500000000000000000000000000');
+const MOCK_GOV_TOKEN_TOTAL_SUPPLY = BigNumber.from('3475000000000000000000');
+const MOCK_GOV_TOKEN_DECIMALS = 18;
 const MOCK_GOV_TOKEN_SYMBOL = 'FRCTL';
 
 function ProposalDetails() {
@@ -94,6 +95,7 @@ function ProposalDetails() {
           </ContentBox>
           <ProposalVotes
             proposal={proposal}
+            govTokenDecimals={MOCK_GOV_TOKEN_DECIMALS}
             govTokenSymbol={MOCK_GOV_TOKEN_SYMBOL}
             govTokenTotalSupply={MOCK_GOV_TOKEN_TOTAL_SUPPLY}
           />

--- a/src/utils/numberFormats.ts
+++ b/src/utils/numberFormats.ts
@@ -7,9 +7,12 @@ export const formatPercentage = (
   numerator: BigNumber | number | string,
   denominator: BigNumber | number | string
 ) => {
-  const divide = bigDecimal.divide(numerator.toString(), denominator.toString(), 18);
-  const percent = parseFloat(bigDecimal.multiply(divide, 100)).toPrecision(3);
-  return percent + '%';
+  const fraction = bigDecimal.divide(numerator.toString(), denominator.toString(), 18);
+  const percent = parseFloat(bigDecimal.multiply(fraction, 100));
+  if (percent < 0.01) {
+    return '< 0.01%';
+  }
+  return Number(percent.toFixed(2)) + '%';
 };
 
 const usdFormatter = new Intl.NumberFormat('en-US', {

--- a/src/utils/numberFormats.ts
+++ b/src/utils/numberFormats.ts
@@ -1,8 +1,15 @@
 import { BigNumber, ethers } from 'ethers';
+import bigDecimal from 'js-big-decimal';
 
 export const DEFAULT_DATE_FORMAT = 'MMM dd, yyyy, h:mm aa';
-export const formatPercentage = (numerator: number, denominator: number) => {
-  return parseFloat(((100 * numerator) / denominator).toPrecision(3)) + '%';
+
+export const formatPercentage = (
+  numerator: BigNumber | number | string,
+  denominator: BigNumber | number | string
+) => {
+  const divide = bigDecimal.divide(numerator.toString(), denominator.toString(), 18);
+  const percent = parseFloat(bigDecimal.multiply(divide, 100)).toPrecision(3);
+  return percent + '%';
 };
 
 const usdFormatter = new Intl.NumberFormat('en-US', {

--- a/src/utils/percentFormat.spec.ts
+++ b/src/utils/percentFormat.spec.ts
@@ -1,0 +1,98 @@
+import { BigNumber } from 'ethers';
+import { formatPercentage } from './numberFormats';
+
+describe('Percent formatting, number', () => {
+  test('correct 100%, number', () => {
+    expect(formatPercentage(1, 1)).toBe('100%');
+  });
+  test('correct 10%, number', () => {
+    expect(formatPercentage(1, 10)).toBe('10%');
+  });
+  test('correct 1%, number', () => {
+    expect(formatPercentage(1, 100)).toBe('1%');
+  });
+  test('correct 0.1%, number', () => {
+    expect(formatPercentage(1, 1000)).toBe('0.1%');
+  });
+  test('correct 0.01%, number', () => {
+    expect(formatPercentage(1, 10000)).toBe('0.01%');
+  });
+  test('correct 0.001%, number', () => {
+    expect(formatPercentage(1, 100000)).toBe('< 0.01%');
+  });
+  test('correct 1.1%, number', () => {
+    expect(formatPercentage(1, 90.9090909091)).toBe('1.1%');
+  });
+  test('correct 1.01%, number', () => {
+    expect(formatPercentage(1, 99.0099009901)).toBe('1.01%');
+  });
+  test('correct 1.001%, number', () => {
+    expect(formatPercentage(1, 99.9000999001)).toBe('1%');
+  });
+});
+
+describe('Percent formatting, string', () => {
+  test('correct 100%, number', () => {
+    expect(formatPercentage('1', '1')).toBe('100%');
+  });
+  test('correct 10%, number', () => {
+    expect(formatPercentage('1', '10')).toBe('10%');
+  });
+  test('correct 1%, number', () => {
+    expect(formatPercentage('1', '100')).toBe('1%');
+  });
+  test('correct 0.1%, number', () => {
+    expect(formatPercentage('1', '1000')).toBe('0.1%');
+  });
+  test('correct 0.01%, number', () => {
+    expect(formatPercentage('1', '10000')).toBe('0.01%');
+  });
+  test('correct 0.001%, number', () => {
+    expect(formatPercentage('1', '100000')).toBe('< 0.01%');
+  });
+  test('correct 1.1%, number', () => {
+    expect(formatPercentage('1', '90.9090909091')).toBe('1.1%');
+  });
+  test('correct 1.01%, number', () => {
+    expect(formatPercentage('1', '99.0099009901')).toBe('1.01%');
+  });
+  test('correct 1.001%, number', () => {
+    expect(formatPercentage('1', '99.9000999001')).toBe('1%');
+  });
+});
+
+describe('Percent formatting, BigNumber', () => {
+  test('correct 100%, number', () => {
+    expect(formatPercentage(BigNumber.from('1'), BigNumber.from('1'))).toBe('100%');
+  });
+  test('correct 10%, number', () => {
+    expect(formatPercentage(BigNumber.from('1'), BigNumber.from('10'))).toBe('10%');
+  });
+  test('correct 1%, number', () => {
+    expect(formatPercentage(BigNumber.from('1'), BigNumber.from('100'))).toBe('1%');
+  });
+  test('correct 0.1%, number', () => {
+    expect(formatPercentage(BigNumber.from('1'), BigNumber.from('1000'))).toBe('0.1%');
+  });
+  test('correct 0.01%, number', () => {
+    expect(formatPercentage(BigNumber.from('1'), BigNumber.from('10000'))).toBe('0.01%');
+  });
+  test('correct 0.001%, number', () => {
+    expect(formatPercentage(BigNumber.from('1'), BigNumber.from('100000'))).toBe('< 0.01%');
+  });
+  test('correct 1.1%, number', () => {
+    expect(formatPercentage(BigNumber.from('10000000000'), BigNumber.from('909090909091'))).toBe(
+      '1.1%'
+    );
+  });
+  test('correct 1.01%, number', () => {
+    expect(formatPercentage(BigNumber.from('10000000000'), BigNumber.from('990099009901'))).toBe(
+      '1.01%'
+    );
+  });
+  test('correct 1.001%, number', () => {
+    expect(formatPercentage(BigNumber.from('10000000000'), BigNumber.from('999000999001'))).toBe(
+      '1%'
+    );
+  });
+});


### PR DESCRIPTION
## Description

Precision percentages using BigNumbers.

The issue is that BigNumbers are integers, so division using them will always lose precision, e.g. 1/2 = 0.

This PR uses the bigDecimal library to handle dividing BigNumbers, as well as adjusts the percent formatter method to take string, number, or BigDecimal.

## Notes

## Testing

I used @mudrila 's test DAO at http://localhost:3000/#/daos/0xeA4b1Ba101ed338BC72a35990a6c962c852Bc075/proposals/0 to view the changes

<img width="880" alt="Screen Shot 2022-11-18 at 10 43 46 PM" src="https://user-images.githubusercontent.com/384559/202832808-4c917ec6-9028-4e57-bf2e-b8ea08c9bd8b.png">
