### PR TITLE
Fix predicted token address

### DIFF
--- a/src/hooks/DAO/useBuildDAOTx.ts
+++ b/src/hooks/DAO/useBuildDAOTx.ts
@@ -1,4 +1,4 @@
-import { VotesToken__factory, GnosisSafe__factory } from '@fractal-framework/fractal-contracts';
+import { GnosisSafe__factory } from '@fractal-framework/fractal-contracts';
 import { BigNumber, ethers } from 'ethers';
 import { useCallback } from 'react';
 import { OZLinearVoting__factory, Usul__factory } from '../../assets/typechain-types/usul';
@@ -246,11 +246,19 @@ const useBuildDAOTx = () => {
           'setUp',
           [encodedInitTokenData]
         );
-        const tokenSalt = getRandomBytes();
+        const tokenByteCodeLinear =
+          '0x602d8060093d393df3363d3d373d3d3d363d73' +
+          votesMasterCopyContract.address.slice(2) +
+          '5af43d82803e903d91602b57fd5bf3';
+        const tokenNonce = getRandomBytes();
+        const tokenSalt = solidityKeccak256(
+          ['bytes32', 'uint256'],
+          [solidityKeccak256(['bytes'], [encodedSetUpTokenData]), tokenNonce]
+        );
         const predictedTokenAddress = getCreate2Address(
           zodiacModuleProxyFactoryContract.address,
           tokenSalt,
-          solidityKeccak256(['bytes'], [VotesToken__factory.bytecode])
+          solidityKeccak256(['bytes'], [tokenByteCodeLinear])
         );
 
         const encodedStrategyInitParams = defaultAbiCoder.encode(
@@ -359,7 +367,7 @@ const useBuildDAOTx = () => {
         const createTokenTx = buildContractCall(
           zodiacModuleProxyFactoryContract,
           'deployModule',
-          [votesMasterCopyContract.address, encodedSetUpTokenData, tokenSalt],
+          [votesMasterCopyContract.address, encodedSetUpTokenData, tokenNonce],
           0,
           false
         );


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->
This PR fixes a bug by updating the logic within `useBuildDAOTx` to correctly predict the token contract address.

## Notes

<!-- Is there any additional information a reviewer should know?  -->

## Issue / Notion doc (if applicable)

<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #XXX` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing
1) Create a new Usul DAO
2) Browse to the proposals, then delegate page
3) Ensure the token data is populated and that it updates with a new delegation
<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.


If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.

New feature work should include a correlating automated integration test via Playwright, in collaboration with the QA team. See this repo's README.md for Playwright setup.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/84364476/204382498-19f51af1-0e71-42fe-9457-b1895988a784.png)
