### PR TITLE
Proposals filtering fixes

### DIFF
--- a/src/components/Proposals/ProposalsList.tsx
+++ b/src/components/Proposals/ProposalsList.tsx
@@ -40,8 +40,10 @@ export default function ProposalsList() {
   const filterTitle =
     filters.length === 1
       ? t(filters[0])
-      : filters.length === allStates.length || filters.length === 0 // No filters selected means no filtering applied
+      : filters.length === allStates.length
       ? t('filterProposalsAllSelected')
+      : filters.length === 0 // No filters selected means no filtering applied
+      ? t('filterProposalsNoneSelected')
       : t('filterProposalsNSelected', { count: filters.length });
 
   return (

--- a/src/components/ui/menus/OptionMenu.tsx
+++ b/src/components/ui/menus/OptionMenu.tsx
@@ -92,6 +92,7 @@ export function OptionMenu({
                   onChange={option.onClick}
                   colorScheme="gold"
                   iconColor="black.900"
+                  marginEnd="0.5rem"
                 />
               )}
               {t(option.optionKey)}

--- a/src/i18n/locales/en/proposal.json
+++ b/src/i18n/locales/en/proposal.json
@@ -62,6 +62,7 @@
     "queueTitle": "Queue Transaction",
     "executeTitle": "Execute Transaction",
     "filterProposalsAllSelected": "All Proposals",
+    "filterProposalsNoneSelected": "No Proposals",
     "filterProposalsNSelected": "Filter {{count}}",
     "filter": "Filter",
     "parent": "Parent",


### PR DESCRIPTION
## Description
Fixes two issues with the proposals filter:
1. Having zero filters selected still says "All Proposals"
2. No right margin between the checkbox and text

## Screenshots (if applicable)

Before
<img width="408" alt="Screenshot 2022-11-29 at 6 26 42 PM" src="https://user-images.githubusercontent.com/384559/204671087-bf80fb72-d479-4838-970a-203c498370ab.png">

After
<img width="357" alt="Screenshot 2022-11-29 at 6 26 18 PM" src="https://user-images.githubusercontent.com/384559/204671067-bd5b4f26-06a4-4c36-a549-02f6064b5c29.png">

