### PR TITLE
Enhancement | Polling safe data

### DIFF
--- a/src/hooks/utils/useUpdateTimer.tsx
+++ b/src/hooks/utils/useUpdateTimer.tsx
@@ -2,10 +2,10 @@ import { useCallback, useEffect, useState } from 'react';
 
 export const useUpdateTimer = (safeAddress?: string) => {
   const [timers, setTimers] = useState<NodeJS.Timer[]>([]);
-  const thirtySeconds = 20000; // in milliseconds
+  const twentySeconds = 20000; // in milliseconds
 
   const setMethodonInterval = useCallback(
-    (getMethod: () => Promise<void>, milliseconds: number = thirtySeconds) => {
+    (getMethod: () => Promise<void>, milliseconds: number = twentySeconds) => {
       Promise.resolve(getMethod());
       const intervalId = setInterval(() => {
         Promise.resolve(getMethod());

--- a/src/hooks/utils/useUpdateTimer.tsx
+++ b/src/hooks/utils/useUpdateTimer.tsx
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export const useUpdateTimer = (safeAddress?: string) => {
+  const [timers, setTimers] = useState<NodeJS.Timer[]>([]);
+  const thirtySeconds = 20000; // in milliseconds
+
+  const setMethodonInterval = useCallback(
+    (getMethod: () => Promise<void>, milliseconds: number = thirtySeconds) => {
+      Promise.resolve(getMethod());
+      const intervalId = setInterval(() => {
+        Promise.resolve(getMethod());
+      }, milliseconds);
+      setTimers(prevState => [...prevState, intervalId]);
+    },
+    []
+  );
+  useEffect(() => {
+    if (!safeAddress) {
+      timers.forEach(timer => clearInterval(timer));
+    }
+  }, [safeAddress, timers]);
+  return { setMethodonInterval };
+};

--- a/src/hooks/utils/useUpdateTimer.tsx
+++ b/src/hooks/utils/useUpdateTimer.tsx
@@ -4,7 +4,7 @@ export const useUpdateTimer = (safeAddress?: string) => {
   const [timers, setTimers] = useState<NodeJS.Timer[]>([]);
   const twentySeconds = 20000; // in milliseconds
 
-  const setMethodonInterval = useCallback(
+  const setMethodOnInterval = useCallback(
     (getMethod: () => Promise<void>, milliseconds: number = twentySeconds) => {
       Promise.resolve(getMethod());
       const intervalId = setInterval(() => {
@@ -19,5 +19,5 @@ export const useUpdateTimer = (safeAddress?: string) => {
       timers.forEach(timer => clearInterval(timer));
     }
   }, [safeAddress, timers]);
-  return { setMethodonInterval };
+  return { setMethodOnInterval };
 };

--- a/src/providers/Fractal/hooks/useGnosisApiServices.ts
+++ b/src/providers/Fractal/hooks/useGnosisApiServices.ts
@@ -7,6 +7,7 @@ import { logError } from '../../../helpers/errorLogging';
 import { useWeb3Provider } from '../../Web3Data/hooks/useWeb3Provider';
 import { GnosisAction, TreasuryAction } from '../constants/actions';
 import { GnosisActions, IGnosis, TreasuryActions } from '../types';
+import { useUpdateTimer } from './../../../hooks/utils/useUpdateTimer';
 
 /**
  * hooks on loading of a Gnosis Module will make requests to Gnosis API endpoints to gather any additional safe information
@@ -26,6 +27,8 @@ export function useGnosisApiServices(
   const {
     state: { signerOrProvider },
   } = useWeb3Provider();
+
+  const { setMethodonInterval } = useUpdateTimer(address);
 
   useEffect(() => {
     if (!account || !signerOrProvider) {
@@ -118,11 +121,12 @@ export function useGnosisApiServices(
   }, [providedSafeAddress, safeService, gnosisDispatch, isGnosisLoading]);
 
   useEffect(() => {
-    getGnosisSafeFungibleAssets();
-    getGnosisSafeNonFungibleAssets();
-    getGnosisSafeTransfers();
-    getGnosisSafeTransactions();
+    setMethodonInterval(getGnosisSafeFungibleAssets);
+    setMethodonInterval(getGnosisSafeNonFungibleAssets);
+    setMethodonInterval(getGnosisSafeTransfers);
+    setMethodonInterval(getGnosisSafeTransactions);
   }, [
+    setMethodonInterval,
     getGnosisSafeFungibleAssets,
     getGnosisSafeNonFungibleAssets,
     getGnosisSafeTransfers,

--- a/src/providers/Fractal/hooks/useGnosisApiServices.ts
+++ b/src/providers/Fractal/hooks/useGnosisApiServices.ts
@@ -28,7 +28,7 @@ export function useGnosisApiServices(
     state: { signerOrProvider },
   } = useWeb3Provider();
 
-  const { setMethodonInterval } = useUpdateTimer(address);
+  const { setMethodOnInterval } = useUpdateTimer(address);
 
   useEffect(() => {
     if (!account || !signerOrProvider) {
@@ -121,12 +121,12 @@ export function useGnosisApiServices(
   }, [providedSafeAddress, safeService, gnosisDispatch, isGnosisLoading]);
 
   useEffect(() => {
-    setMethodonInterval(getGnosisSafeFungibleAssets);
-    setMethodonInterval(getGnosisSafeNonFungibleAssets);
-    setMethodonInterval(getGnosisSafeTransfers);
-    setMethodonInterval(getGnosisSafeTransactions);
+    setMethodOnInterval(getGnosisSafeFungibleAssets);
+    setMethodOnInterval(getGnosisSafeNonFungibleAssets);
+    setMethodOnInterval(getGnosisSafeTransfers);
+    setMethodOnInterval(getGnosisSafeTransactions);
   }, [
-    setMethodonInterval,
+    setMethodOnInterval,
     getGnosisSafeFungibleAssets,
     getGnosisSafeNonFungibleAssets,
     getGnosisSafeTransfers,


### PR DESCRIPTION
## Description
Adds polling hook that will continuing call an async method to retrieve Safe information every 20s
<!-- Please describe your changes -->

## Notes

<!-- Is there any additional information a reviewer should know?  -->

## Issue / Notion doc (if applicable)

<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #XXX` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing
Navigate to a DAO. (Dashboard). and send the safe some eth from wallet. after a while your event should appear
<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.

New feature work should include a correlating automated integration test via Playwright, in collaboration with the QA team. See this repo's README.md for Playwright setup.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
