### PR TITLE
BugFix | Clean DAO data when not viewing DAO

### DIFF
--- a/src/hooks/DAO/useDAOController.ts
+++ b/src/hooks/DAO/useDAOController.ts
@@ -66,14 +66,4 @@ export default function useDAOController() {
       }
     }
   }, [errorMessage, account, loading, isProviderLoading, gnosisDispatch, address, navigate]);
-
-  useEffect(() => {
-    return () => {
-      if (!params.address) {
-        gnosisDispatch({ type: GnosisAction.RESET });
-        treasuryDispatch({ type: TreasuryAction.RESET });
-        governanceDispatch({ type: GovernanceAction.RESET });
-      }
-    };
-  }, [params.address, gnosisDispatch, treasuryDispatch, governanceDispatch]);
 }

--- a/src/providers/Fractal/FractalProvider.tsx
+++ b/src/providers/Fractal/FractalProvider.tsx
@@ -1,10 +1,15 @@
-import { ReactNode, useMemo, useReducer } from 'react';
+import { ReactNode, useEffect, useMemo, useReducer } from 'react';
+import { useMatch } from 'react-router-dom';
+import { BASE_ROUTES } from '../../routes/constants';
 import {
   gnosisInitialState,
   governanceInitialState,
   treasuryInitialState,
   connectedAccountInitialState,
+  GnosisAction,
+  TreasuryAction,
 } from './constants';
+import { GovernanceAction } from './governance/actions';
 import { useGnosisGovernance } from './governance/hooks/useGnosisGovernance';
 import { governanceReducer, initializeGovernanceState } from './governance/reducer';
 import { useAccount } from './hooks/account/useAccount';
@@ -62,6 +67,18 @@ export function FractalProvider({ children }: { children: ReactNode }) {
   });
   useGnosisGovernance({ governance, gnosis, governanceDispatch });
   useNodes({ gnosis, gnosisDispatch });
+
+  const isHome = useMatch(BASE_ROUTES.landing);
+  const isCreate = useMatch(BASE_ROUTES.create);
+
+  useEffect(() => {
+    // Resets Fractal state when not viewing DAO
+    if (!!isHome || !!isCreate) {
+      gnosisDispatch({ type: GnosisAction.RESET });
+      treasuryDispatch({ type: TreasuryAction.RESET });
+      governanceDispatch({ type: GovernanceAction.RESET });
+    }
+  }, [gnosisDispatch, treasuryDispatch, governanceDispatch, isHome, isCreate]);
 
   const value = useMemo(
     () => ({

--- a/src/providers/Fractal/FractalProvider.tsx
+++ b/src/providers/Fractal/FractalProvider.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useEffect, useMemo, useReducer } from 'react';
 import { useMatch } from 'react-router-dom';
-import { BASE_ROUTES } from '../../routes/constants';
+import { DAO_ROUTES } from '../../routes/constants';
 import {
   gnosisInitialState,
   governanceInitialState,
@@ -68,17 +68,16 @@ export function FractalProvider({ children }: { children: ReactNode }) {
   useGnosisGovernance({ governance, gnosis, governanceDispatch });
   useNodes({ gnosis, gnosisDispatch });
 
-  const isHome = useMatch(BASE_ROUTES.landing);
-  const isCreate = useMatch(BASE_ROUTES.create);
+  const isViewingDAO = useMatch(DAO_ROUTES.daos.path);
 
   useEffect(() => {
     // Resets Fractal state when not viewing DAO
-    if (!!isHome || !!isCreate) {
+    if (!isViewingDAO) {
       gnosisDispatch({ type: GnosisAction.RESET });
       treasuryDispatch({ type: TreasuryAction.RESET });
       governanceDispatch({ type: GovernanceAction.RESET });
     }
-  }, [gnosisDispatch, treasuryDispatch, governanceDispatch, isHome, isCreate]);
+  }, [gnosisDispatch, treasuryDispatch, governanceDispatch, isViewingDAO]);
 
   const value = useMemo(
     () => ({

--- a/src/providers/Fractal/reducers/gnosis.ts
+++ b/src/providers/Fractal/reducers/gnosis.ts
@@ -38,7 +38,7 @@ export const gnosisReducer = (state: IGnosis, action: GnosisActions): IGnosis =>
     case GnosisAction.INVALIDATE:
     case GnosisAction.RESET:
       // @note safeService is preserved and doesn't need to be reset
-      return initializeGnosisState({ safeService: state.safeService, ...gnosisInitialState });
+      return initializeGnosisState({ ...gnosisInitialState, safeService: state.safeService });
     default:
       return state;
   }

--- a/src/routes/FractalRoutes.tsx
+++ b/src/routes/FractalRoutes.tsx
@@ -1,30 +1,10 @@
-import { useEffect } from 'react';
-import { Route, Routes, useMatch } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import DaoCreate from '../pages/DaoCreate';
 import Home from '../pages/Home';
-import { GnosisAction, TreasuryAction } from '../providers/Fractal/constants';
-import { GovernanceAction } from '../providers/Fractal/governance/actions';
-import { useFractal } from '../providers/Fractal/hooks/useFractal';
 import DAORoutes from './DAORoutes';
 import { BASE_ROUTES, DAO_ROUTES } from './constants';
 
 function FractalRoutes() {
-  const {
-    dispatches: { gnosisDispatch, governanceDispatch, treasuryDispatch },
-  } = useFractal();
-
-  const isHome = useMatch(BASE_ROUTES.landing);
-  const isCreate = useMatch(BASE_ROUTES.create);
-
-  useEffect(() => {
-    // Resets Fractal state when not viewing DAO
-    if (!!isHome || !!isCreate) {
-      gnosisDispatch({ type: GnosisAction.RESET });
-      treasuryDispatch({ type: TreasuryAction.RESET });
-      governanceDispatch({ type: GovernanceAction.RESET });
-    }
-  }, [gnosisDispatch, treasuryDispatch, governanceDispatch, isHome, isCreate]);
-
   return (
     <Routes>
       <Route

--- a/src/routes/FractalRoutes.tsx
+++ b/src/routes/FractalRoutes.tsx
@@ -1,10 +1,30 @@
-import { Route, Routes } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Route, Routes, useMatch } from 'react-router-dom';
 import DaoCreate from '../pages/DaoCreate';
 import Home from '../pages/Home';
+import { GnosisAction, TreasuryAction } from '../providers/Fractal/constants';
+import { GovernanceAction } from '../providers/Fractal/governance/actions';
+import { useFractal } from '../providers/Fractal/hooks/useFractal';
 import DAORoutes from './DAORoutes';
 import { BASE_ROUTES, DAO_ROUTES } from './constants';
 
 function FractalRoutes() {
+  const {
+    dispatches: { gnosisDispatch, governanceDispatch, treasuryDispatch },
+  } = useFractal();
+
+  const isHome = useMatch(BASE_ROUTES.landing);
+  const isCreate = useMatch(BASE_ROUTES.create);
+
+  useEffect(() => {
+    // Resets Fractal state when not viewing DAO
+    if (!!isHome || !!isCreate) {
+      gnosisDispatch({ type: GnosisAction.RESET });
+      treasuryDispatch({ type: TreasuryAction.RESET });
+      governanceDispatch({ type: GovernanceAction.RESET });
+    }
+  }, [gnosisDispatch, treasuryDispatch, governanceDispatch, isHome, isCreate]);
+
   return (
     <Routes>
       <Route


### PR DESCRIPTION
## Description
Added a useEffect to clear state when not within DAO.

<!-- Please describe your changes -->

## Notes
- I tried a few different approaches here. I would prefer to have `DAOController` make this update, but because of how React Route is works. params of nested routes won't be recongnized by parent. So moving `useDAOController` isn't really an option and doesn't work. 
- There isn't any real way (and you shouldn't) update state on unMount.
- I believe I had a version of this before and had deleted it as it was causing some issues with loading. This version using routeMatch to check if state should be reset. instead of data from state.
<!-- Is there any additional information a reviewer should know?  -->

## Issue / Notion doc (if applicable)
Closes #793
<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #XXX` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing
Go to all the different routes and back home again. make sure state is changing correctly
<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.

New feature work should include a correlating automated integration test via Playwright, in collaboration with the QA team. See this repo's README.md for Playwright setup.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
