### PR TITLE
check if there are any votes before render

### DIFF
--- a/src/components/Proposals/ProposalVotes.tsx
+++ b/src/components/Proposals/ProposalVotes.tsx
@@ -163,28 +163,30 @@ function ProposalVotes({
           </GridItem>
         </Grid>
       </ContentBox>
-      <ContentBox bg={BACKGROUND_SEMI_TRANSPARENT}>
-        <Text textStyle="text-lg-mono-medium">{t('votesTitle', { ns: 'proposal' })}</Text>
-        <Divider
-          color="chocolate.700"
-          marginTop={4}
-          marginBottom={4}
-        />
-        <Flex
-          flexWrap="wrap"
-          gap={4}
-        >
-          {votes.map(vote => (
-            <ProposalVoteItem
-              key={vote.voter}
-              vote={vote}
-              govTokenTotalSupply={governanceToken.totalSupply!}
-              govTokenDecimals={governanceToken.decimals!}
-              govTokenSymbol={governanceToken.symbol!}
-            />
-          ))}
-        </Flex>
-      </ContentBox>
+      {votes.length !== 0 && (
+        <ContentBox bg={BACKGROUND_SEMI_TRANSPARENT}>
+          <Text textStyle="text-lg-mono-medium">{t('votesTitle', { ns: 'proposal' })}</Text>
+          <Divider
+            color="chocolate.700"
+            marginTop={4}
+            marginBottom={4}
+          />
+          <Flex
+            flexWrap="wrap"
+            gap={4}
+          >
+            {votes.map(vote => (
+              <ProposalVoteItem
+                key={vote.voter}
+                vote={vote}
+                govTokenTotalSupply={governanceToken.totalSupply!}
+                govTokenDecimals={governanceToken.decimals!}
+                govTokenSymbol={governanceToken.symbol!}
+              />
+            ))}
+          </Flex>
+        </ContentBox>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Description

This simple PR checks if there are votes before rendering the vote history component.

## Notes

There are no listeners set up re-render state once a vote occurs. This requires a manual refresh to see the new state after a vote is completed.
## Issue / Notion doc (if applicable)

<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #833 ` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing

1. Create a usul dao
2. Create a random proposal
3. If you have not voted, the component should not render.

## Screenshots (if applicable)
<img width="722" alt="image" src="https://user-images.githubusercontent.com/69045872/208723345-b6883bbd-6fd0-4619-bcce-5e6b250d59b1.png">

