### PR TITLE
Bugfix | Proposal Execution Refresh

### DIFF
--- a/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
@@ -24,7 +24,7 @@ export function TxActions({
 }) {
   const {
     gnosis: { safe, safeService },
-    actions: { refreshGnosisTransactions },
+    actions: { refreshSafeData },
   } = useFractal();
   const {
     state: { account, signerOrProvider, chainId },
@@ -59,7 +59,7 @@ export function TxActions({
         successMessage: t('successSign'),
         successCallback: async (signature: string) => {
           await safeService.confirmTransaction(proposal.proposalNumber, signature);
-          setTimeout(() => Promise.resolve(refreshGnosisTransactions()), 500);
+          setTimeout(() => Promise.resolve(refreshSafeData()), 500);
         },
       });
     } catch (e) {
@@ -99,7 +99,7 @@ export function TxActions({
         pendingMessage: t('pendingExecute', { ns: 'transaction' }),
         successMessage: t('successExecute', { ns: 'transaction' }),
         successCallback: async () => {
-          setTimeout(() => Promise.resolve(refreshGnosisTransactions()), 1000);
+          setTimeout(() => Promise.resolve(refreshSafeData()), 1000);
         },
       });
     } catch (e) {
@@ -140,7 +140,7 @@ export function TxActions({
         pendingMessage: t('pendingExecute', { ns: 'transaction' }),
         successMessage: t('successExecute', { ns: 'transaction' }),
         successCallback: async () => {
-          setTimeout(() => Promise.resolve(refreshGnosisTransactions()), 1000);
+          setTimeout(() => Promise.resolve(refreshSafeData()), 1000);
         },
       });
     } catch (e) {

--- a/src/components/ui/cards/DAOInfoCard.tsx
+++ b/src/components/ui/cards/DAOInfoCard.tsx
@@ -166,6 +166,7 @@ export function DAONodeCard(props: IDAOInfoCard) {
 
   return (
     <Box
+      mt="1rem"
       minH="6.75rem"
       bg={BACKGROUND_SEMI_TRANSPARENT}
       p="1rem"

--- a/src/hooks/DAO/proposal/useExecuteProposal.ts
+++ b/src/hooks/DAO/proposal/useExecuteProposal.ts
@@ -17,6 +17,7 @@ export default function useExecuteProposal() {
   } = useWeb3Provider();
   const { usulContract } = useUsul();
   const {
+    actions: { refreshSafeData },
     governance,
     dispatches: { governanceDispatch },
   } = useFractal();
@@ -60,11 +61,19 @@ export default function useExecuteProposal() {
         failedMessage: t('failedExecute'),
         successMessage: t('successExecute'),
         successCallback: () => {
+          refreshSafeData();
           updateProposalState(BigNumber.from(proposal.proposalNumber));
         },
       });
     },
-    [contractCallExecuteProposal, signerOrProvider, t, usulContract, updateProposalState]
+    [
+      contractCallExecuteProposal,
+      signerOrProvider,
+      t,
+      usulContract,
+      updateProposalState,
+      refreshSafeData,
+    ]
   );
 
   return {

--- a/src/hooks/DAO/proposal/useSubmitProposal.ts
+++ b/src/hooks/DAO/proposal/useSubmitProposal.ts
@@ -19,7 +19,7 @@ export default function useSubmitProposal() {
   const { multiSendContract } = useSafeContracts();
   const { usulContract, votingStrategiesAddresses } = useUsul();
   const {
-    actions: { refreshGnosisTransactions },
+    actions: { refreshSafeData },
     gnosis: { safe },
   } = useFractal();
   const {
@@ -109,7 +109,7 @@ export default function useSubmitProposal() {
               }
             )
           );
-          await refreshGnosisTransactions();
+          await refreshSafeData();
           if (successCallback) {
             successCallback(safe.address);
           }
@@ -164,7 +164,7 @@ export default function useSubmitProposal() {
       signerOrProvider,
       multiSendContract,
       chainId,
-      refreshGnosisTransactions,
+      refreshSafeData,
     ]
   );
 

--- a/src/hooks/DAO/useCreateSubDAOProposal.ts
+++ b/src/hooks/DAO/useCreateSubDAOProposal.ts
@@ -10,7 +10,7 @@ import useBuildDAOTx from './useBuildDAOTx';
 
 export const useCreateSubDAOProposal = () => {
   const { multiSendContract } = useSafeContracts();
-  const { t } = useTranslation(['daoCreate', 'proposal']);
+  const { t } = useTranslation(['daoCreate', 'proposal', 'proposalMetadata']);
 
   const { submitProposal, pendingCreateTx, canUserCreateProposal } = useSubmitProposal();
   const [build] = useBuildDAOTx();
@@ -37,7 +37,7 @@ export const useCreateSubDAOProposal = () => {
           targets: [multiSendContract.address],
           values: [BigNumber.from('0')],
           calldatas: [multiSendContract.interface.encodeFunctionData('multiSend', [safeTx])],
-          title: t('createSubDAO'),
+          title: t('Create a proposal', { ns: 'proposalMetadata' }),
           description: 'to:' + multiSendContract.address + '_ txs:' + safeTx,
           documentationUrl: '',
         };

--- a/src/hooks/DAO/useCreateSubDAOProposal.ts
+++ b/src/hooks/DAO/useCreateSubDAOProposal.ts
@@ -10,7 +10,7 @@ import useBuildDAOTx from './useBuildDAOTx';
 
 export const useCreateSubDAOProposal = () => {
   const { multiSendContract } = useSafeContracts();
-  const { t } = useTranslation('daoCreate');
+  const { t } = useTranslation(['daoCreate', 'proposal']);
 
   const { submitProposal, pendingCreateTx, canUserCreateProposal } = useSubmitProposal();
   const [build] = useBuildDAOTx();
@@ -37,15 +37,15 @@ export const useCreateSubDAOProposal = () => {
           targets: [multiSendContract.address],
           values: [BigNumber.from('0')],
           calldatas: [multiSendContract.interface.encodeFunctionData('multiSend', [safeTx])],
-          title: 'Create SubDAO',
+          title: t('createSubDAO'),
           description: 'to:' + multiSendContract.address + '_ txs:' + safeTx,
           documentationUrl: '',
         };
         submitProposal({
           proposalData,
           pendingToastMessage: t('createSubDAOPendingToastMessage'),
-          successToastMessage: t('createSubDAOSuccessToastMessage'),
-          failedToastMessage: t('createSubDAOFailureToastMessage'),
+          successToastMessage: t('proposalCreateSuccessToastMessage', { ns: 'proposal' }),
+          failedToastMessage: t('proposalCreateFailureToastMessage', { ns: 'proposal' }),
           successCallback,
         });
       };

--- a/src/hooks/DAO/useCreateSubDAOProposal.ts
+++ b/src/hooks/DAO/useCreateSubDAOProposal.ts
@@ -37,7 +37,7 @@ export const useCreateSubDAOProposal = () => {
           targets: [multiSendContract.address],
           values: [BigNumber.from('0')],
           calldatas: [multiSendContract.interface.encodeFunctionData('multiSend', [safeTx])],
-          title: t('Create a proposal', { ns: 'proposalMetadata' }),
+          title: t('Create a SubDAO proposal', { ns: 'proposalMetadata' }),
           description: 'to:' + multiSendContract.address + '_ txs:' + safeTx,
           documentationUrl: '',
         };

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -8,6 +8,7 @@ import LANGUAGES_EN from './locales/en/languages.json';
 import MENU_EN from './locales/en/menu.json';
 import MODALS_EN from './locales/en/modals.json';
 import PROPOSAL_EN from './locales/en/proposal.json';
+import PROPOSAL_METADATA_EN from './locales/en/proposalMetadata.json';
 import SIDEBAR_EN from './locales/en/sidebar.json';
 import TRANSACTION_EN from './locales/en/transaction.json';
 import TREASURY_EN from './locales/en/treasury.json';
@@ -50,6 +51,7 @@ export const supportedLanguages = {
     menu: MENU_EN,
     dashboard: DASHBOARD_EN,
     proposal: PROPOSAL_EN,
+    proposalMetadata: PROPOSAL_METADATA_EN,
     transaction: TRANSACTION_EN,
     treasury: TREASURY_EN,
     sidebar: SIDEBAR_EN,

--- a/src/i18n/locales/en/daoCreate.json
+++ b/src/i18n/locales/en/daoCreate.json
@@ -73,7 +73,6 @@
     "titleTokenParams": "Token Metadata",
     "titleAddress": "Address",
     "titleAmount": "Amount",
-    "Create SubDAO": "Create SubDAO",
     "createSubDAOPendingToastMessage": "Creating your SubDAO Proposal",
     "createSubDAOSuccessToastMessage": "Deployment successful",
     "createSubDAOFailureToastMessage": "Deployment failed",

--- a/src/i18n/locales/en/daoCreate.json
+++ b/src/i18n/locales/en/daoCreate.json
@@ -74,7 +74,7 @@
     "titleAddress": "Address",
     "titleAmount": "Amount",
     "Create SubDAO": "Create SubDAO",
-    "createSubDAO": "Creating your SubDAO Proposal",
+    "createSubDAOPendingToastMessage": "Creating your SubDAO Proposal",
     "createSubDAOSuccessToastMessage": "Deployment successful",
     "createSubDAOFailureToastMessage": "Deployment failed",
     "helperAllocations": "Unallocated tokens will be placed in your DAO's treasury"

--- a/src/i18n/locales/en/daoCreate.json
+++ b/src/i18n/locales/en/daoCreate.json
@@ -73,7 +73,8 @@
     "titleTokenParams": "Token Metadata",
     "titleAddress": "Address",
     "titleAmount": "Amount",
-    "createSubDAOPendingToastMessage": "Deploying your subDAO",
+    "Create SubDAO": "Create SubDAO",
+    "createSubDAO": "Creating your SubDAO Proposal",
     "createSubDAOSuccessToastMessage": "Deployment successful",
     "createSubDAOFailureToastMessage": "Deployment failed",
     "helperAllocations": "Unallocated tokens will be placed in your DAO's treasury"

--- a/src/i18n/locales/en/proposalMetadata.json
+++ b/src/i18n/locales/en/proposalMetadata.json
@@ -1,0 +1,3 @@
+{
+  "Create a proposal": "Create a proposal"
+}

--- a/src/i18n/locales/en/proposalMetadata.json
+++ b/src/i18n/locales/en/proposalMetadata.json
@@ -1,3 +1,3 @@
 {
-  "Create a proposal": "Create a proposal"
+  "Create a SubDAO proposal": "Create a SubDAO proposal"
 }

--- a/src/i18n/locales/uk/daoCreate.json
+++ b/src/i18n/locales/uk/daoCreate.json
@@ -73,8 +73,5 @@
     "titleTokenParams": "Метадані токену",
     "titleAddress": "Адреса",
     "titleAmount": "Кількість",
-    "createSubDAOPendingToastMessage": "Створюємо ваше subDAO",
-    "createSubDAOSuccessToastMessage": "Створення subDAO пройшло успішно",
-    "createSubDAOFailureToastMessage": "Помилка при створенні subDAO",
     "helperAllocations": "Неросподілені токени будуть надіслани до скарбниці вашого DAO"
 }

--- a/src/pages/SubDaoCreate/index.tsx
+++ b/src/pages/SubDaoCreate/index.tsx
@@ -2,13 +2,17 @@ import { useNavigate } from 'react-router-dom';
 import DaoCreator from '../../components/DaoCreator';
 import { GnosisDAO } from '../../components/DaoCreator/provider/types';
 import { useCreateSubDAOProposal } from '../../hooks/DAO/useCreateSubDAOProposal';
+import { useFractal } from '../../providers/Fractal/hooks/useFractal';
 import { DAO_ROUTES } from '../../routes/constants';
 
 function SubDaoCreate() {
   const navigate = useNavigate();
+  const {
+    actions: { refreshSafeData },
+  } = useFractal();
 
-  const successCallback = (daoAddress: string) => {
-    // @todo should navigate to proposals
+  const successCallback = async (daoAddress: string) => {
+    await refreshSafeData();
     navigate(DAO_ROUTES.dao.relative(daoAddress));
   };
 

--- a/src/pages/SubDaoCreate/index.tsx
+++ b/src/pages/SubDaoCreate/index.tsx
@@ -8,6 +8,7 @@ function SubDaoCreate() {
   const navigate = useNavigate();
 
   const successCallback = (daoAddress: string) => {
+    // @todo should navigate to proposals
     navigate(DAO_ROUTES.dao.relative(daoAddress));
   };
 

--- a/src/providers/Fractal/FractalProvider.tsx
+++ b/src/providers/Fractal/FractalProvider.tsx
@@ -54,7 +54,7 @@ export function FractalProvider({ children }: { children: ReactNode }) {
 
   useLocalStorage();
 
-  const { getGnosisSafeTransactions } = useGnosisApiServices(
+  const { getGnosisSafeTransactions, getGnosisSafeInfo } = useGnosisApiServices(
     gnosis,
     treasuryDispatch,
     gnosisDispatch
@@ -98,7 +98,10 @@ export function FractalProvider({ children }: { children: ReactNode }) {
         gnosisDispatch,
       },
       actions: {
-        refreshGnosisTransactions: getGnosisSafeTransactions,
+        refreshSafeData: async () => {
+          await getGnosisSafeTransactions();
+          await getGnosisSafeInfo();
+        },
         lookupModules,
         getVetoGuardContracts,
         lookupFreezeData,
@@ -110,6 +113,7 @@ export function FractalProvider({ children }: { children: ReactNode }) {
       treasury,
       account,
       getGnosisSafeTransactions,
+      getGnosisSafeInfo,
       lookupModules,
       getVetoGuardContracts,
       lookupFreezeData,

--- a/src/providers/Fractal/hooks/useGnosisApiServices.ts
+++ b/src/providers/Fractal/hooks/useGnosisApiServices.ts
@@ -102,30 +102,34 @@ export function useGnosisApiServices(
     }
   }, [address, safeService, gnosisDispatch]);
 
-  useEffect(() => {
+  const getGnosisSafeInfo = useCallback(async () => {
     if (!providedSafeAddress || !safeService || !isGnosisLoading) {
       return;
     }
-    (async () => {
+    try {
       gnosisDispatch({
         type: GnosisAction.SET_SAFE,
         payload: await safeService.getSafeInfo(providedSafeAddress),
       });
-    })();
+    } catch (e) {
+      logError(e);
+    }
   }, [providedSafeAddress, safeService, gnosisDispatch, isGnosisLoading]);
 
   useEffect(() => {
+    setMethodOnInterval(getGnosisSafeInfo);
     setMethodOnInterval(getGnosisSafeFungibleAssets);
     setMethodOnInterval(getGnosisSafeNonFungibleAssets);
     setMethodOnInterval(getGnosisSafeTransfers);
     setMethodOnInterval(getGnosisSafeTransactions);
   }, [
     setMethodOnInterval,
+    getGnosisSafeInfo,
     getGnosisSafeFungibleAssets,
     getGnosisSafeNonFungibleAssets,
     getGnosisSafeTransfers,
     getGnosisSafeTransactions,
   ]);
 
-  return { getGnosisSafeTransactions };
+  return { getGnosisSafeTransactions, getGnosisSafeInfo };
 }

--- a/src/providers/Fractal/types/state.ts
+++ b/src/providers/Fractal/types/state.ts
@@ -23,7 +23,7 @@ export interface IFractalContext {
     gnosisDispatch: React.Dispatch<GnosisActions>;
   };
   actions: {
-    refreshGnosisTransactions: () => Promise<void>;
+    refreshSafeData: () => Promise<void>;
     lookupModules: (_moduleAddresses: string[]) => Promise<IGnosisModuleData[] | undefined>;
     getVetoGuardContracts: (
       _guardAddress: string,


### PR DESCRIPTION
## Description
Going off the pattern I started to setup in #888, I've added a `refresh` method to the actions object in Fractal Provider. To start I've only included Transactions and SafeInfo as these retreive the info we need right now (to save on requests). When call these function don't return anything but update state. 

One other note. Since we don't really know what information we are trying to refresh when a proposal is executed. This isn't always going to catch the new DAO on the initial refresh. This PR also takes care of adding the SafeInfo into the interval as well. So child DAO will appear after some time.
<!-- Please describe your changes -->

## Notes
I've also updated the copy based on the request in the card.
<!-- Is there any additional information a reviewer should know?  -->

## Issue / Notion doc (if applicable)
Closes #884 
<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #XXX` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.

New feature work should include a correlating automated integration test via Playwright, in collaboration with the QA team. See this repo's README.md for Playwright setup.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
