### PR TITLE
BugFix | Etherscan URL not linked correctly

### DIFF
--- a/src/hooks/utils/useSubDomain.tsx
+++ b/src/hooks/utils/useSubDomain.tsx
@@ -6,12 +6,12 @@ function useSubDomain() {
   const [subdomain, setSubdomain] = useState('');
 
   useEffect(() => {
-    if (!['localhost', 'homestead'].includes(provider._network.name)) {
+    if (['localhost', 'homestead', 'mainnet'].includes(provider.network.name)) {
       setSubdomain('');
       return;
     }
 
-    setSubdomain(`${provider._network.name}.`);
+    setSubdomain(`${provider.network.name}.`);
   }, [provider]);
 
   return subdomain;


### PR DESCRIPTION
## Description
Noticed that I wasn't able to use the transaction hash link to etherscan properly. a conditional just needed to be flipped.
<!-- Please describe your changes -->

## Notes

<!-- Is there any additional information a reviewer should know?  -->

## Issue / Notion doc (if applicable)

<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #XXX` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.

New feature work should include a correlating automated integration test via Playwright, in collaboration with the QA team. See this repo's README.md for Playwright setup.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
