### PR TITLE
Handle decoding error for proposal executable code

### DIFF
--- a/src/components/ui/proposal/ProposalExecutableCode.tsx
+++ b/src/components/ui/proposal/ProposalExecutableCode.tsx
@@ -1,4 +1,6 @@
 import {
+  Alert,
+  AlertTitle,
   Accordion,
   AccordionButton,
   AccordionIcon,
@@ -8,6 +10,7 @@ import {
   Flex,
   Text,
 } from '@chakra-ui/react';
+import { Info } from '@decent-org/fractal-ui';
 import { useTranslation } from 'react-i18next';
 import { TxProposal } from '../../../providers/Fractal/types';
 import { DecodedTransaction } from '../../../types';
@@ -34,6 +37,7 @@ function TransactionRow({ paramKey, value }: { paramKey: string; value: string }
   );
 }
 function TransactionBlock({ transaction }: { transaction: DecodedTransaction }) {
+  const { t } = useTranslation('proposal');
   return (
     <Flex
       width="full"
@@ -63,6 +67,15 @@ function TransactionBlock({ transaction }: { transaction: DecodedTransaction }) 
         paramKey="paramValue"
         value={transaction.value}
       />
+      {transaction.decodingFailed && (
+        <Alert
+          status="info"
+          mt={2}
+        >
+          <Info boxSize="24px" />
+          <AlertTitle>{t('decodingFailedMessage')}</AlertTitle>
+        </Alert>
+      )}
     </Flex>
   );
 }

--- a/src/i18n/locales/en/proposal.json
+++ b/src/i18n/locales/en/proposal.json
@@ -97,5 +97,6 @@
     "paramFunction": "function",
     "paramTypes": "parameter types",
     "paramInputs": "parameter inputs",
-    "paramValue": "transaction value"
+    "paramValue": "transaction value",
+    "decodingFailedMessage": "Unable to decode transaction's data."
 }

--- a/src/pages/ProposalCreate/index.tsx
+++ b/src/pages/ProposalCreate/index.tsx
@@ -161,6 +161,7 @@ function ProposalCreate() {
           onClick={() =>
             safe.address ? navigate(`/daos/${safe.address}/proposals`) : navigate('/daos/')
           }
+          disabled={pendingCreateTx}
         >
           {t('cancel', { ns: 'common' })}
         </Button>

--- a/src/pages/ProposalDetails/index.tsx
+++ b/src/pages/ProposalDetails/index.tsx
@@ -55,6 +55,7 @@ function ProposalDetails() {
           paddingLeft={0}
           size="lg"
           variant="text"
+          display="inline-flex"
         >
           <LeftArrow />
           {t('proposals', { ns: 'sidebar' })}

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -7,6 +7,7 @@ export interface DecodedTransaction {
   function: string;
   parameterTypes: string[];
   parameterValues: string[];
+  decodingFailed?: boolean;
 }
 export interface MetaTransaction {
   to: string;

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -38,6 +38,7 @@ export const decodeTransactions = async (
           function: 'unknown',
           parameterTypes: [],
           parameterValues: [],
+          decodingFailed: true,
         };
       }
     })


### PR DESCRIPTION
## Description

This PR fixes set of bugs:
1. Whole "< Proposals" button area is clickable, and not just button content
2. Showing informational message that transaction's data decoding failed
3. Marking "Cancel" button as disabled during proposal creation

## Notes

N/A

## Issue / Notion doc (if applicable)

Closes #876 
Closes #921 
Closes #917 

## Testing

Testing #876 

1. Create Proposal with broken data (you can put method that does not exist on target contract - that's sufficient enough)
2. Open proposal's executable code
3. There should be info message saying that it was unable to decode transaction data **for each transaction that was failed to decode**.

Note - this works only for Usul, as for Multisig we're not showing executable code if Gnosis API does not return decoded data. Since we're not decoding data through separate request - there's no sensible way to know, that there was an error decoding transactions data 

Testing #917 

1. Go to any Proposal details page (both Usul and Multisig)
2. Try to click on area far right from "< Proposals" button - it shouldn't work
3. You still should be able to get back to Proposals list by clicking directly on button or arrow nearby.

Testing #921 
1. Create new proposal
2. During signing transaction - "Cancel x" button should be disabled and not clickable. Clicking that should do nothing.

## Screenshots (if applicable)
<img width="1601" alt="Знімок екрана 2023-01-17 о 23 54 49" src="https://user-images.githubusercontent.com/25801162/213023531-678dc0b9-6642-4957-9c04-0ba3e0e1155b.png">
