### PR TITLE
change references to Timelock to Queue

### DIFF
--- a/src/i18n/locales/en/daoCreate.json
+++ b/src/i18n/locales/en/daoCreate.json
@@ -35,7 +35,7 @@
     "labelExecutionPeriod": "Execution Period",
     "helperExecutionPeriod": "The length of time (in minutes) a successful proposal must be executed within",
     "exampleExecutionPeriod": "2,880 minutes = 2 days",
-    "labelTimelockPeriod": "Timelock Period",
+    "labelTimelockPeriod": "Queue Period",
     "helperTimelockPeriod": "The length of time (in minutes) a passed proposal must wait to be executed on the blockchain",
     "exampleTimelockPeriod": "1,440 minutes = 1 day",
     "labelVetoVotesThreshold": "Veto Votes Threshold",

--- a/src/i18n/locales/en/proposal.json
+++ b/src/i18n/locales/en/proposal.json
@@ -78,7 +78,7 @@
     "transactionExecutionAlertMessage": "Transactions execute in the order they are added",
     "labelProposalVotingPeriod": "Voting Period",
     "labelProposalQuorum": "Quorum",
-    "labelProposalTimelock": "Timelock",
+    "labelProposalTimelock": "Queue",
     "labelProposalSigners": "Signers",
     "support": "Support",
     "signers": "Signers",

--- a/src/i18n/locales/uk/daoCreate.json
+++ b/src/i18n/locales/uk/daoCreate.json
@@ -33,7 +33,6 @@
     "labelExecutionPeriod": "Період виконання",
     "helperExecutionPeriod": "Тривалість часу (у хвилинах) коли успішна пропозиція має бути виконана",
     "exampleExecutionPeriod": "2880 хвилин = 2 дні",
-    "labelTimelockPeriod": "Період блокування",
     "helperTimelockPeriod": "Тривалість часу (у хвилинах) скільки успішна пропозиція має знаходитись у очікуванні перед тим як виконати иї у блокчейни",
     "exampleTimelockPeriod": "1440 хвилин = 1 доба",
     "labelVetoVotesThreshold": "Поріг голосів ветування",

--- a/src/i18n/locales/uk/proposal.json
+++ b/src/i18n/locales/uk/proposal.json
@@ -52,7 +52,6 @@
     "transactionExecutionAlertMessage": "Транзакції виконуються у порядку, у якому вони додаються",
     "labelProposalVotingPeriod": "Період голосування",
     "labelProposalQuorum": "Кворум",
-    "labelProposalTimelock": "Час блокування",
     "labelProposalSigners": "Підписанти",
     "support": "Підтримка",
     "signers": "Підписанти",


### PR DESCRIPTION
## Description

internally these are termed different things depending on the governance details, but user facing we're just calling both time periods the Queue period.

This is just cleaning up two instances where we didn't change this.