### PR TITLE
Fix time distances not translated

### DIFF
--- a/src/hooks/utils/useTimeHelpers.tsx
+++ b/src/hooks/utils/useTimeHelpers.tsx
@@ -1,12 +1,14 @@
 import { formatDistance } from 'date-fns';
 import { useCallback } from 'react';
+import { useDateFNSLocale } from '../../i18n';
 export const useTimeHelpers = () => {
+  const locale = useDateFNSLocale();
   const getTimeDuration = useCallback(
     (_seconds: number | string | null | undefined): string | undefined => {
       if (!_seconds) return;
-      return formatDistance(0, Number(_seconds) * 1000, { includeSeconds: true });
+      return formatDistance(0, Number(_seconds) * 1000, { includeSeconds: true, locale: locale });
     },
-    []
+    [locale]
   );
   return { getTimeDuration };
 };

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,3 +1,4 @@
+import { enUS, uk } from 'date-fns/locale';
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
@@ -85,3 +86,18 @@ i18n
   });
 
 export default i18n;
+
+/**
+ * @returns the date-fns Locale corresponding to the current i18n language setting
+ */
+export const useDateFNSLocale = () => {
+  let locale = undefined;
+  switch (i18n.language) {
+    case 'uk':
+      locale = uk;
+      break;
+    default:
+      locale = enUS;
+  }
+  return locale;
+};


### PR DESCRIPTION
## Description

Translates the times in DAO homepage and proposal creation displayed using `formatDistance`

## Issue / Notion doc (if applicable)

closes https://github.com/decent-dao/fractal-interface/issues/799

## Screenshots (if applicable)

<img width="939" alt="Screenshot 2023-01-22 at 12 28 05 PM" src="https://user-images.githubusercontent.com/384559/213947189-77fc9507-7896-4fb1-bcd6-a69187b68172.png">
<img width="446" alt="Screenshot 2023-01-22 at 12 31 54 PM" src="https://user-images.githubusercontent.com/384559/213947190-688f9d2e-633f-4213-9cc4-bf8c7cfd2c7a.png">


