### PR TITLE
switch to permanent discord invite link

### DIFF
--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -1,3 +1,3 @@
 export const URL_FAQ = 'https://docs.fractalframework.xyz/welcome-to-fractal/user-guides/faq';
-export const URL_DISCORD = 'https://discord.com/invite/decent-dao';
+export const URL_DISCORD = 'https://discord.gg/Zh2emKspVF';
 export const URL_DOCS = 'https://docs.fractalframework.xyz/welcome-to-fractal/';

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -1,3 +1,3 @@
 export const URL_FAQ = 'https://docs.fractalframework.xyz/welcome-to-fractal/user-guides/faq';
-export const URL_DISCORD = 'https://discord.gg/Zh2emKspVF';
+export const URL_DISCORD = 'https://discord.com/invite/Zh2emKspVF';
 export const URL_DOCS = 'https://docs.fractalframework.xyz/welcome-to-fractal/';

--- a/src/i18n/locales/en/proposalMetadata.json
+++ b/src/i18n/locales/en/proposalMetadata.json
@@ -1,3 +1,3 @@
 {
-  "Create a SubDAO proposal": "Create a SubDAO proposal"
+  "Create a subDAO proposal": "Create a subDAO proposal"
 }

--- a/tests/home/visit.spec.ts
+++ b/tests/home/visit.spec.ts
@@ -48,7 +48,7 @@ test('FAQ button works', async () => {
 
 test('Discord button works', async () => {
   const tab = await home.clickDiscordNewTab();
-  await expect(tab).toHaveURL('https://discord.gg/Zh2emKspVF');
+  await expect(tab).toHaveURL('https://discord.com/invite/Zh2emKspVF');
 });
 
 test('Docs button works', async () => {

--- a/tests/home/visit.spec.ts
+++ b/tests/home/visit.spec.ts
@@ -48,7 +48,7 @@ test('FAQ button works', async () => {
 
 test('Discord button works', async () => {
   const tab = await home.clickDiscordNewTab();
-  await expect(tab).toHaveURL('https://discord.com/invite/decent-dao');
+  await expect(tab).toHaveURL('https://discord.gg/Zh2emKspVF');
 });
 
 test('Docs button works', async () => {


### PR DESCRIPTION
## Description

The Discord invite link fails if we run out of Discord server boosts, which has happened at least 2 times that I've noticed..

This switched to a permanent, non vanity link instead.