### PR TITLE
Caching | Caches decoded transaction data

### DIFF
--- a/src/providers/Fractal/governance/hooks/useUsulProposals.ts
+++ b/src/providers/Fractal/governance/hooks/useUsulProposals.ts
@@ -6,9 +6,10 @@ import {
   ProposalCreatedEvent,
   ProposalCanceledEvent,
 } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/FractalUsul';
-import { Dispatch, useCallback, useEffect } from 'react';
+import { Dispatch, useCallback, useEffect, useRef } from 'react';
 import { useProvider } from 'wagmi';
 import { TypedListener } from '../../../../assets/typechain-types/usul/common';
+import { DecodedTransaction } from '../../../../types';
 import { decodeTransactions } from '../../../../utils/crypto';
 import { useNetworkConfg } from '../../../NetworkConfig/NetworkConfigProvider';
 import { IGovernance, TxProposalState, UsulProposal, VOTE_CHOICES } from '../../types';
@@ -24,6 +25,7 @@ interface IUseUsulProposals {
 export default function useUsulProposals({ governance, governanceDispatch }: IUseUsulProposals) {
   const provider = useProvider();
   const { safeBaseURL } = useNetworkConfg();
+  const metaDataMapping = useRef<Map<string, DecodedTransaction[]>>(new Map());
 
   const {
     txProposalsInfo,
@@ -185,13 +187,10 @@ export default function useUsulProposals({ governance, governanceDispatch }: IUs
       return;
     }
     const loadProposals = async () => {
-      const proposalCreatedFilter = usulContract.asProvider.filters.ProposalCreated();
-      const proposalMetaDataCreatedFilter =
-        usulContract.asProvider.filters.ProposalMetadataCreated();
-      const proposalCreatedEvents = await usulContract.asProvider.queryFilter(
-        proposalCreatedFilter
-      );
-      const proposalMetaDataCreatedEvents = await usulContract.asProvider.queryFilter(
+      const proposalCreatedFilter = usulContract.asSigner.filters.ProposalCreated();
+      const proposalMetaDataCreatedFilter = usulContract.asSigner.filters.ProposalMetadataCreated();
+      const proposalCreatedEvents = await usulContract.asSigner.queryFilter(proposalCreatedFilter);
+      const proposalMetaDataCreatedEvents = await usulContract.asSigner.queryFilter(
         proposalMetaDataCreatedFilter
       );
 
@@ -202,15 +201,20 @@ export default function useUsulProposals({ governance, governanceDispatch }: IUs
           );
           let metaData;
           if (metaDataEvent) {
+            let decodedTransactions = metaDataMapping.current.get(metaDataEvent.data);
+            if (!decodedTransactions) {
+              decodedTransactions = await decodeTransactions(
+                metaDataEvent.args.transactions,
+                safeBaseURL
+              );
+              metaDataMapping.current.set(metaDataEvent.data, decodedTransactions);
+            }
             metaData = {
               title: metaDataEvent.args.title,
               description: metaDataEvent.args.description,
               documentationUrl: metaDataEvent.args.documentationUrl,
               transactions: metaDataEvent.args.transactions,
-              decodedTransactions: await decodeTransactions(
-                metaDataEvent.args.transactions,
-                safeBaseURL
-              ),
+              decodedTransactions,
             };
           }
           return mapProposalCreatedEventToProposal(

--- a/src/providers/Fractal/governance/hooks/useUsulProposals.ts
+++ b/src/providers/Fractal/governance/hooks/useUsulProposals.ts
@@ -201,13 +201,13 @@ export default function useUsulProposals({ governance, governanceDispatch }: IUs
           );
           let metaData;
           if (metaDataEvent) {
-            let decodedTransactions = metaDataMapping.current.get(metaDataEvent.data);
+            let decodedTransactions = metaDataMapping.current.get(args.proposalNumber.toString());
             if (!decodedTransactions) {
               decodedTransactions = await decodeTransactions(
                 metaDataEvent.args.transactions,
                 safeBaseURL
               );
-              metaDataMapping.current.set(metaDataEvent.data, decodedTransactions);
+              metaDataMapping.current.set(args.proposalNumber.toString(), decodedTransactions);
             }
             metaData = {
               title: metaDataEvent.args.title,


### PR DESCRIPTION
## Description
Saw an opportunity to 'cache' some requests. When loading several Usul Token Proposals, For each tx, a request is sent to 'decode' the transaction. This happens on every interval. This data is only saved to a mapping within the `useUsulProposals` itself will help save costs per session.

This is only a quick bandaid, as we work towards a look at the data-layer of the app. On load I noticed that the proposals are loaded (the function is called) 3 times, and then on every the interval, noting for later.
<!-- Please describe your changes -->

## Notes

<!-- Is there any additional information a reviewer should know?  -->

## Issue / Notion doc (if applicable)

<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #XXX` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.

New feature work should include a correlating automated integration test via Playwright, in collaboration with the QA team. See this repo's README.md for Playwright setup.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
