### PR TITLE
Cache ENS and DAO name lookups

### DIFF
--- a/src/hooks/utils/useDisplayName.ts
+++ b/src/hooks/utils/useDisplayName.ts
@@ -19,6 +19,7 @@ const useDisplayName = (account?: string | null) => {
   const { data: ensName } = useEnsName({
     address: account as Address,
     chainId: networkId,
+    cacheTime: 1000 * 60 * 30, // 30 min
   });
 
   const [accountSubstring, setAccountSubstring] = useState<string>();

--- a/src/providers/Fractal/hooks/account/useLocalStorage.ts
+++ b/src/providers/Fractal/hooks/account/useLocalStorage.ts
@@ -13,8 +13,7 @@ export enum CacheKeys {
   AUDIT_WARNING_SHOWN = 'audit_warning_shown',
   // name.eth -> 0x0 caching
   ENS_RESOLVE_PREFIX = 'ens_resolve_',
-  // 0x0 -> name.eth caching
-  ENS_LOOKUP_PREFIX = 'ens_lookup_',
+  DAO_NAME_PREFIX = 'dao_name_',
 }
 
 /**


### PR DESCRIPTION
## Description

Cache requests to look up ENS names, as well as our own DAO name contract.

We could refactor ENS resolving to use `useEnsResolver`, similar to what we're doing with `useEnsName` and get their built in caching, but I decided to leave as is for now.
