### PR TITLE
make polygon specific provider / signer calls dynamic to the network

### DIFF
--- a/src/helpers/crypto.ts
+++ b/src/helpers/crypto.ts
@@ -194,7 +194,7 @@ export const buildMultiSendSafeTx = (
 /**
  * TODO explain why exactly we're doing this...
  */
-export function eventRPC<T>(connection: ContractConnection<T>, chainId: number): T {
+export function getEventRPC<T>(connection: ContractConnection<T>, chainId: number): T {
   switch (chainId) {
     case polygon.id:
       return connection.asProvider;

--- a/src/helpers/crypto.ts
+++ b/src/helpers/crypto.ts
@@ -192,7 +192,23 @@ export const buildMultiSendSafeTx = (
 };
 
 /**
- * TODO explain why exactly we're doing this...
+ * Explained by our future overlord, ChatGPT:
+ *
+ * On networks like Polygon where block times are very short, events cannot be
+ * looked up without specifying a starting block number. If a user connects their
+ * Metamask wallet to Polygon as a public provider, attempting to load events in
+ * this way would cause it to fail, resulting in reduced performance and a high
+ * probability of failure.
+ *
+ * While power users can swap out the remote procedure call (RPC) in their
+ * Metamask for a custom one, this option is not feasible for most users. As a
+ * solution, the contract can be used as a provider with our own keys, allowing
+ * us to use our own rate limits.
+ *
+ * This gave rise to the idea of updating the useSafeContracts hook to enable
+ * connections as signers (using a connected wallet) or using our own keys as
+ * providers. The asSigner option is essentially connecting as a signer or provider,
+ * making it the ideal choice for most normal use cases.
  */
 export function getEventRPC<T>(connection: ContractConnection<T>, chainId: number): T {
   switch (chainId) {

--- a/src/helpers/crypto.ts
+++ b/src/helpers/crypto.ts
@@ -194,7 +194,7 @@ export const buildMultiSendSafeTx = (
 /**
  * TODO explain why exactly we're doing this...
  */
-export function asProper<T>(connection: ContractConnection<T>, chainId: number): T {
+export function eventRPC<T>(connection: ContractConnection<T>, chainId: number): T {
   switch (chainId) {
     case polygon.id:
       return connection.asProvider;

--- a/src/helpers/crypto.ts
+++ b/src/helpers/crypto.ts
@@ -1,5 +1,7 @@
 import { TypedDataSigner } from '@ethersproject/abstract-signer';
 import { BigNumber, Contract, constants, utils, BigNumberish, Signer } from 'ethers';
+import { polygon } from 'wagmi/chains';
+import { ContractConnection } from '../types';
 import { MetaTransaction, SafePostTransaction, SafeTransaction } from '../types/transaction';
 
 export interface SafeSignature {
@@ -188,3 +190,15 @@ export const buildMultiSendSafeTx = (
 ): SafeTransaction => {
   return buildContractCall(multiSend, 'multiSend', [encodeMultiSend(txs)], nonce, true, overrides);
 };
+
+/**
+ * TODO explain why exactly we're doing this...
+ */
+export function asProper<T>(connection: ContractConnection<T>, chainId: number): T {
+  switch (chainId) {
+    case polygon.id:
+      return connection.asProvider;
+    default:
+      return connection.asSigner;
+  }
+}

--- a/src/hooks/DAO/useDAOName.ts
+++ b/src/hooks/DAO/useDAOName.ts
@@ -1,5 +1,7 @@
+import { FractalRegistry } from '@fractal-framework/fractal-contracts';
 import { useCallback, useEffect, useState } from 'react';
 import { Address, useEnsName, useProvider } from 'wagmi';
+import { asProper } from '../../helpers';
 import useSafeContracts from '../safe/useSafeContracts';
 import { createAccountSubstring } from '../utils/useDisplayName';
 
@@ -35,9 +37,8 @@ export default function useDAOName({ address }: { address?: string }) {
       setDAORegistryName(createAccountSubstring(address));
       return;
     }
-    const events = await fractalRegistryContract.asSigner.queryFilter(
-      fractalRegistryContract.asSigner.filters.FractalNameUpdated(address)
-    );
+    const proper = asProper<FractalRegistry>(fractalRegistryContract, networkId);
+    const events = await proper.queryFilter(proper.filters.FractalNameUpdated(address));
 
     const latestEvent = events.pop();
     if (!latestEvent) {
@@ -47,7 +48,7 @@ export default function useDAOName({ address }: { address?: string }) {
 
     const { daoName } = latestEvent.args;
     setDAORegistryName(daoName);
-  }, [fractalRegistryContract, address, ensName]);
+  }, [address, ensName, fractalRegistryContract, networkId]);
 
   useEffect(() => {
     (async () => {

--- a/src/hooks/DAO/useDAOName.ts
+++ b/src/hooks/DAO/useDAOName.ts
@@ -1,7 +1,7 @@
 import { FractalRegistry } from '@fractal-framework/fractal-contracts';
 import { useCallback, useEffect, useState } from 'react';
 import { Address, useEnsName, useProvider } from 'wagmi';
-import { eventRPC } from '../../helpers';
+import { getEventRPC } from '../../helpers';
 import useSafeContracts from '../safe/useSafeContracts';
 import { createAccountSubstring } from '../utils/useDisplayName';
 
@@ -37,7 +37,7 @@ export default function useDAOName({ address }: { address?: string }) {
       setDAORegistryName(createAccountSubstring(address));
       return;
     }
-    const rpc = eventRPC<FractalRegistry>(fractalRegistryContract, networkId);
+    const rpc = getEventRPC<FractalRegistry>(fractalRegistryContract, networkId);
     const events = await rpc.queryFilter(rpc.filters.FractalNameUpdated(address));
 
     const latestEvent = events.pop();

--- a/src/hooks/DAO/useDAOName.ts
+++ b/src/hooks/DAO/useDAOName.ts
@@ -1,7 +1,7 @@
 import { FractalRegistry } from '@fractal-framework/fractal-contracts';
 import { useCallback, useEffect, useState } from 'react';
 import { Address, useEnsName, useProvider } from 'wagmi';
-import { asProper } from '../../helpers';
+import { eventRPC } from '../../helpers';
 import useSafeContracts from '../safe/useSafeContracts';
 import { createAccountSubstring } from '../utils/useDisplayName';
 
@@ -37,8 +37,8 @@ export default function useDAOName({ address }: { address?: string }) {
       setDAORegistryName(createAccountSubstring(address));
       return;
     }
-    const proper = asProper<FractalRegistry>(fractalRegistryContract, networkId);
-    const events = await proper.queryFilter(proper.filters.FractalNameUpdated(address));
+    const rpc = eventRPC<FractalRegistry>(fractalRegistryContract, networkId);
+    const events = await rpc.queryFilter(rpc.filters.FractalNameUpdated(address));
 
     const latestEvent = events.pop();
     if (!latestEvent) {

--- a/src/providers/Fractal/FractalProvider.tsx
+++ b/src/providers/Fractal/FractalProvider.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useEffect, useMemo, useReducer } from 'react';
 import { useMatch } from 'react-router-dom';
 import { DAO_ROUTES } from '../../routes/constants';
+import { useNetworkConfg } from '../NetworkConfig/NetworkConfigProvider';
 import {
   gnosisInitialState,
   governanceInitialState,
@@ -27,6 +28,8 @@ import { TreasuryReducer, initializeTreasuryState } from './reducers/treasury';
  * Uses Context API to provider DAO information to app
  */
 export function FractalProvider({ children }: { children: ReactNode }) {
+  const { chainId } = useNetworkConfg();
+
   const [gnosis, gnosisDispatch] = useReducer(
     gnosisReducer,
     gnosisInitialState,
@@ -57,20 +60,22 @@ export function FractalProvider({ children }: { children: ReactNode }) {
     gnosisDispatch
   );
 
-  const { lookupModules } = useGnosisModuleTypes(gnosisDispatch, gnosis.safe.modules);
+  const { lookupModules } = useGnosisModuleTypes(gnosisDispatch, chainId, gnosis.safe.modules);
 
   useDispatchDAOName({ address: gnosis.safe.address, gnosisDispatch });
   useAccount({
     safeAddress: gnosis.safe.address,
     accountDispatch,
   });
+
   const { getVetoGuardContracts } = useVetoContracts(
     gnosisDispatch,
+    chainId,
     gnosis.safe.guard,
     gnosis.modules
   );
 
-  useGnosisGovernance({ governance, gnosis, governanceDispatch });
+  useGnosisGovernance({ governance, gnosis, governanceDispatch, chainId });
   useNodes({ gnosis, gnosisDispatch });
   const { lookupFreezeData } = useFreezeData(gnosis.guardContracts, gnosisDispatch);
 

--- a/src/providers/Fractal/governance/hooks/useGnosisGovernance.ts
+++ b/src/providers/Fractal/governance/hooks/useGnosisGovernance.ts
@@ -10,15 +10,17 @@ interface IUseGnosisGovernance {
   governance: IGovernance;
   gnosis: IGnosis;
   governanceDispatch: Dispatch<GovernanceActions>;
+  chainId: number;
 }
 
 export const useGnosisGovernance = ({
   governance,
   gnosis,
   governanceDispatch,
+  chainId,
 }: IUseGnosisGovernance) => {
   // load voting contracts
-  useVotingContracts({ gnosis, governanceDispatch });
+  useVotingContracts({ gnosis, governanceDispatch, chainId });
   // if voting contracts are loaded, load governance data
   const governanceTokenData = useGovernanceTokenData(governance.contracts);
 

--- a/src/providers/Fractal/governance/hooks/useUsulProposals.ts
+++ b/src/providers/Fractal/governance/hooks/useUsulProposals.ts
@@ -10,7 +10,7 @@ import {
 import { Dispatch, useCallback, useEffect, useRef } from 'react';
 import { useProvider } from 'wagmi';
 import { TypedListener } from '../../../../assets/typechain-types/usul/common';
-import { eventRPC } from '../../../../helpers';
+import { getEventRPC } from '../../../../helpers';
 import { DecodedTransaction } from '../../../../types';
 import { decodeTransactions } from '../../../../utils/crypto';
 import { useNetworkConfg } from '../../../NetworkConfig/NetworkConfigProvider';
@@ -43,7 +43,7 @@ export default function useUsulProposals({ governance, governanceDispatch }: IUs
       if (!usulContract || !ozLinearVotingContract) {
         return;
       }
-      const rpc = eventRPC<FractalUsul>(usulContract, provider.network.chainId);
+      const rpc = getEventRPC<FractalUsul>(usulContract, provider.network.chainId);
       const proposalMetaDataCreatedFilter = rpc.filters.ProposalMetadataCreated();
       const proposalMetaDataCreatedEvents = await rpc.queryFilter(proposalMetaDataCreatedFilter);
       const metaDataEvent = proposalMetaDataCreatedEvents.find(event =>

--- a/src/providers/Fractal/governance/hooks/useUsulProposals.ts
+++ b/src/providers/Fractal/governance/hooks/useUsulProposals.ts
@@ -69,7 +69,8 @@ export default function useUsulProposals({ governance, governanceDispatch }: IUs
         usulContract,
         ozLinearVotingContract,
         provider,
-        provider.network.chainId
+        provider.network.chainId,
+        metaData
       );
 
       const proposals = [...txProposalsInfo.txProposals, proposal];

--- a/src/providers/Fractal/governance/hooks/useUsulProposals.ts
+++ b/src/providers/Fractal/governance/hooks/useUsulProposals.ts
@@ -10,7 +10,7 @@ import {
 import { Dispatch, useCallback, useEffect, useRef } from 'react';
 import { useProvider } from 'wagmi';
 import { TypedListener } from '../../../../assets/typechain-types/usul/common';
-import { asProper } from '../../../../helpers';
+import { eventRPC } from '../../../../helpers';
 import { DecodedTransaction } from '../../../../types';
 import { decodeTransactions } from '../../../../utils/crypto';
 import { useNetworkConfg } from '../../../NetworkConfig/NetworkConfigProvider';
@@ -43,9 +43,9 @@ export default function useUsulProposals({ governance, governanceDispatch }: IUs
       if (!usulContract || !ozLinearVotingContract) {
         return;
       }
-      const proper = asProper<FractalUsul>(usulContract, provider.network.chainId);
-      const proposalMetaDataCreatedFilter = proper.filters.ProposalMetadataCreated();
-      const proposalMetaDataCreatedEvents = await proper.queryFilter(proposalMetaDataCreatedFilter);
+      const rpc = eventRPC<FractalUsul>(usulContract, provider.network.chainId);
+      const proposalMetaDataCreatedFilter = rpc.filters.ProposalMetadataCreated();
+      const proposalMetaDataCreatedEvents = await rpc.queryFilter(proposalMetaDataCreatedFilter);
       const metaDataEvent = proposalMetaDataCreatedEvents.find(event =>
         event.args.proposalId.eq(proposalNumber)
       );

--- a/src/providers/Fractal/governance/hooks/useVotingContracts.ts
+++ b/src/providers/Fractal/governance/hooks/useVotingContracts.ts
@@ -5,7 +5,7 @@ import {
   ModuleProxyFactory,
 } from '@fractal-framework/fractal-contracts';
 import { Dispatch, useEffect, useMemo, useCallback } from 'react';
-import { eventRPC } from '../../../../helpers';
+import { getEventRPC } from '../../../../helpers';
 import useSafeContracts from '../../../../hooks/safe/useSafeContracts';
 import { ContractConnection } from '../../../../types';
 import { GovernanceAction, GovernanceActions } from '../actions';
@@ -60,13 +60,13 @@ export const useVotingContracts = ({
     let ozLinearContract: ContractConnection<OZLinearVoting> | undefined;
     let tokenContract: ContractConnection<VotesToken> | undefined;
 
-    const votingContractAddress = await eventRPC<FractalUsul>(usulContract, chainId)
+    const votingContractAddress = await getEventRPC<FractalUsul>(usulContract, chainId)
       .queryFilter(usulModule.filters.EnabledStrategy())
       .then(strategiesEnabled => {
         return strategiesEnabled[0].args.strategy;
       });
 
-    const rpc = eventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId);
+    const rpc = getEventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId);
     const filter = rpc.filters.ModuleProxyCreation(votingContractAddress, null);
     const votingContractMasterCopyAddress = await rpc.queryFilter(filter).then(proxiesCreated => {
       return proxiesCreated[0].args.masterCopy;

--- a/src/providers/Fractal/governance/hooks/useVotingContracts.ts
+++ b/src/providers/Fractal/governance/hooks/useVotingContracts.ts
@@ -97,13 +97,14 @@ export const useVotingContracts = ({
       },
     });
   }, [
-    fractalUsulMasterCopyContract,
-    votesTokenMasterCopyContract,
-    governanceDispatch,
     zodiacModuleProxyFactoryContract,
     linearVotingMasterCopyContract,
-    usulModule,
+    votesTokenMasterCopyContract,
+    fractalUsulMasterCopyContract,
     isGnosisLoading,
+    usulModule,
+    chainId,
+    governanceDispatch,
   ]);
 
   useEffect(() => {

--- a/src/providers/Fractal/governance/hooks/useVotingContracts.ts
+++ b/src/providers/Fractal/governance/hooks/useVotingContracts.ts
@@ -5,7 +5,7 @@ import {
   ModuleProxyFactory,
 } from '@fractal-framework/fractal-contracts';
 import { Dispatch, useEffect, useMemo, useCallback } from 'react';
-import { asProper } from '../../../../helpers';
+import { eventRPC } from '../../../../helpers';
 import useSafeContracts from '../../../../hooks/safe/useSafeContracts';
 import { ContractConnection } from '../../../../types';
 import { GovernanceAction, GovernanceActions } from '../actions';
@@ -60,19 +60,17 @@ export const useVotingContracts = ({
     let ozLinearContract: ContractConnection<OZLinearVoting> | undefined;
     let tokenContract: ContractConnection<VotesToken> | undefined;
 
-    const votingContractAddress = await asProper<FractalUsul>(usulContract, chainId)
+    const votingContractAddress = await eventRPC<FractalUsul>(usulContract, chainId)
       .queryFilter(usulModule.filters.EnabledStrategy())
       .then(strategiesEnabled => {
         return strategiesEnabled[0].args.strategy;
       });
 
-    const proper = asProper<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId);
-    const filter = proper.filters.ModuleProxyCreation(votingContractAddress, null);
-    const votingContractMasterCopyAddress = await proper
-      .queryFilter(filter)
-      .then(proxiesCreated => {
-        return proxiesCreated[0].args.masterCopy;
-      });
+    const rpc = eventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId);
+    const filter = rpc.filters.ModuleProxyCreation(votingContractAddress, null);
+    const votingContractMasterCopyAddress = await rpc.queryFilter(filter).then(proxiesCreated => {
+      return proxiesCreated[0].args.masterCopy;
+    });
 
     if (votingContractMasterCopyAddress === linearVotingMasterCopyContract.asProvider.address) {
       ozLinearContract = {

--- a/src/providers/Fractal/hooks/useGnosisModuleTypes.ts
+++ b/src/providers/Fractal/hooks/useGnosisModuleTypes.ts
@@ -1,6 +1,6 @@
 import { ModuleProxyFactory } from '@fractal-framework/fractal-contracts';
 import { Dispatch, useEffect, useCallback } from 'react';
-import { asProper } from '../../../helpers';
+import { eventRPC } from '../../../helpers';
 import useSafeContracts from '../../../hooks/safe/useSafeContracts';
 import { GnosisAction } from '../constants';
 import { GnosisActions, GnosisModuleType, IGnosisModuleData } from '../types';
@@ -26,10 +26,10 @@ export function useGnosisModuleTypes(
         return;
       }
 
-      const proper = asProper<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId);
+      const rpc = eventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId);
       const getMasterCopyAddress = async (proxyAddress: string): Promise<string> => {
-        const filter = proper.filters.ModuleProxyCreation(proxyAddress, null);
-        return proper.queryFilter(filter).then(proxiesCreated => {
+        const filter = rpc.filters.ModuleProxyCreation(proxyAddress, null);
+        return rpc.queryFilter(filter).then(proxiesCreated => {
           return proxiesCreated[0].args.masterCopy;
         });
       };

--- a/src/providers/Fractal/hooks/useGnosisModuleTypes.ts
+++ b/src/providers/Fractal/hooks/useGnosisModuleTypes.ts
@@ -1,10 +1,13 @@
+import { ModuleProxyFactory } from '@fractal-framework/fractal-contracts';
 import { Dispatch, useEffect, useCallback } from 'react';
+import { asProper } from '../../../helpers';
 import useSafeContracts from '../../../hooks/safe/useSafeContracts';
 import { GnosisAction } from '../constants';
 import { GnosisActions, GnosisModuleType, IGnosisModuleData } from '../types';
 
 export function useGnosisModuleTypes(
   gnosisDispatch: Dispatch<GnosisActions>,
+  chainId: number,
   moduleAddresses?: string[]
 ) {
   const {
@@ -23,16 +26,12 @@ export function useGnosisModuleTypes(
         return;
       }
 
+      const proper = asProper<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId);
       const getMasterCopyAddress = async (proxyAddress: string): Promise<string> => {
-        const filter = zodiacModuleProxyFactoryContract.asSigner.filters.ModuleProxyCreation(
-          proxyAddress,
-          null
-        );
-        return zodiacModuleProxyFactoryContract.asSigner
-          .queryFilter(filter)
-          .then(proxiesCreated => {
-            return proxiesCreated[0].args.masterCopy;
-          });
+        const filter = proper.filters.ModuleProxyCreation(proxyAddress, null);
+        return proper.queryFilter(filter).then(proxiesCreated => {
+          return proxiesCreated[0].args.masterCopy;
+        });
       };
 
       const modules = await Promise.all(

--- a/src/providers/Fractal/hooks/useGnosisModuleTypes.ts
+++ b/src/providers/Fractal/hooks/useGnosisModuleTypes.ts
@@ -69,6 +69,7 @@ export function useGnosisModuleTypes(
       zodiacModuleProxyFactoryContract,
       fractalUsulMasterCopyContract,
       fractalModuleMasterCopyContract,
+      chainId,
     ]
   );
 

--- a/src/providers/Fractal/hooks/useGnosisModuleTypes.ts
+++ b/src/providers/Fractal/hooks/useGnosisModuleTypes.ts
@@ -1,6 +1,6 @@
 import { ModuleProxyFactory } from '@fractal-framework/fractal-contracts';
 import { Dispatch, useEffect, useCallback } from 'react';
-import { eventRPC } from '../../../helpers';
+import { getEventRPC } from '../../../helpers';
 import useSafeContracts from '../../../hooks/safe/useSafeContracts';
 import { GnosisAction } from '../constants';
 import { GnosisActions, GnosisModuleType, IGnosisModuleData } from '../types';
@@ -26,7 +26,7 @@ export function useGnosisModuleTypes(
         return;
       }
 
-      const rpc = eventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId);
+      const rpc = getEventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId);
       const getMasterCopyAddress = async (proxyAddress: string): Promise<string> => {
         const filter = rpc.filters.ModuleProxyCreation(proxyAddress, null);
         return rpc.queryFilter(filter).then(proxiesCreated => {

--- a/src/providers/Fractal/hooks/useVetoContracts.ts
+++ b/src/providers/Fractal/hooks/useVetoContracts.ts
@@ -1,6 +1,7 @@
-import { UsulVetoGuard, VetoGuard } from '@fractal-framework/fractal-contracts';
+import { ModuleProxyFactory, UsulVetoGuard, VetoGuard } from '@fractal-framework/fractal-contracts';
 import { ethers } from 'ethers';
 import { Dispatch, useEffect, useCallback } from 'react';
+import { asProper } from '../../../helpers';
 import useSafeContracts from '../../../hooks/safe/useSafeContracts';
 import { GnosisAction } from '../constants';
 import {
@@ -15,6 +16,7 @@ import { ContractConnection } from './../../../types/contract';
 
 export function useVetoContracts(
   gnosisDispatch: Dispatch<GnosisActions>,
+  chainId: number,
   guardAddress?: string,
   modules?: IGnosisModuleData[]
 ) {
@@ -39,11 +41,11 @@ export function useVetoContracts(
       }
 
       const getMasterCopyAddress = async (proxyAddress: string): Promise<string> => {
-        const filter = zodiacModuleProxyFactoryContract.asSigner.filters.ModuleProxyCreation(
-          proxyAddress,
-          null
-        );
-        return zodiacModuleProxyFactoryContract.asSigner
+        const filter = asProper<ModuleProxyFactory>(
+          zodiacModuleProxyFactoryContract,
+          chainId
+        ).filters.ModuleProxyCreation(proxyAddress, null);
+        return asProper<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId)
           .queryFilter(filter)
           .then(proxiesCreated => {
             return proxiesCreated[0].args.masterCopy;
@@ -112,8 +114,9 @@ export function useVetoContracts(
       zodiacModuleProxyFactoryContract,
       gnosisVetoGuardMasterCopyContract,
       usulVetoGuardMasterCopyContract,
-      vetoERC20VotingMasterCopyContract,
       vetoMultisigVotingMasterCopyContract,
+      vetoERC20VotingMasterCopyContract,
+      chainId,
     ]
   );
 

--- a/src/providers/Fractal/hooks/useVetoContracts.ts
+++ b/src/providers/Fractal/hooks/useVetoContracts.ts
@@ -1,7 +1,7 @@
 import { ModuleProxyFactory, UsulVetoGuard, VetoGuard } from '@fractal-framework/fractal-contracts';
 import { ethers } from 'ethers';
 import { Dispatch, useEffect, useCallback } from 'react';
-import { eventRPC } from '../../../helpers';
+import { getEventRPC } from '../../../helpers';
 import useSafeContracts from '../../../hooks/safe/useSafeContracts';
 import { GnosisAction } from '../constants';
 import {
@@ -41,11 +41,11 @@ export function useVetoContracts(
       }
 
       const getMasterCopyAddress = async (proxyAddress: string): Promise<string> => {
-        const filter = eventRPC<ModuleProxyFactory>(
+        const filter = getEventRPC<ModuleProxyFactory>(
           zodiacModuleProxyFactoryContract,
           chainId
         ).filters.ModuleProxyCreation(proxyAddress, null);
-        return eventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId)
+        return getEventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId)
           .queryFilter(filter)
           .then(proxiesCreated => {
             return proxiesCreated[0].args.masterCopy;

--- a/src/providers/Fractal/hooks/useVetoContracts.ts
+++ b/src/providers/Fractal/hooks/useVetoContracts.ts
@@ -1,7 +1,7 @@
 import { ModuleProxyFactory, UsulVetoGuard, VetoGuard } from '@fractal-framework/fractal-contracts';
 import { ethers } from 'ethers';
 import { Dispatch, useEffect, useCallback } from 'react';
-import { asProper } from '../../../helpers';
+import { eventRPC } from '../../../helpers';
 import useSafeContracts from '../../../hooks/safe/useSafeContracts';
 import { GnosisAction } from '../constants';
 import {
@@ -41,11 +41,11 @@ export function useVetoContracts(
       }
 
       const getMasterCopyAddress = async (proxyAddress: string): Promise<string> => {
-        const filter = asProper<ModuleProxyFactory>(
+        const filter = eventRPC<ModuleProxyFactory>(
           zodiacModuleProxyFactoryContract,
           chainId
         ).filters.ModuleProxyCreation(proxyAddress, null);
-        return asProper<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId)
+        return eventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract, chainId)
           .queryFilter(filter)
           .then(proxiesCreated => {
             return proxiesCreated[0].args.masterCopy;

--- a/src/providers/Fractal/utils/usul.ts
+++ b/src/providers/Fractal/utils/usul.ts
@@ -4,7 +4,7 @@ import {
   SafeMultisigTransactionResponse,
 } from '@safe-global/safe-service-client';
 import { BigNumber } from 'ethers';
-import { asProper } from '../../../helpers';
+import { eventRPC } from '../../../helpers';
 import { logError } from '../../../helpers/errorLogging';
 import { createAccountSubstring } from '../../../hooks/utils/useDisplayName';
 import { ContractConnection } from '../../../types';
@@ -113,7 +113,7 @@ export const mapProposalCreatedEventToProposal = async (
   metaData?: ProposalMetaData
 ) => {
   const strategyContract = linearVotingMasterCopyContract.asSigner.attach(strategyAddress);
-  const strategyContractProvider = asProper<OZLinearVoting>(
+  const strategyContractProvider = eventRPC<OZLinearVoting>(
     linearVotingMasterCopyContract,
     chainId
   ).attach(strategyAddress);

--- a/src/providers/Fractal/utils/usul.ts
+++ b/src/providers/Fractal/utils/usul.ts
@@ -4,7 +4,7 @@ import {
   SafeMultisigTransactionResponse,
 } from '@safe-global/safe-service-client';
 import { BigNumber } from 'ethers';
-import { eventRPC } from '../../../helpers';
+import { getEventRPC } from '../../../helpers';
 import { logError } from '../../../helpers/errorLogging';
 import { createAccountSubstring } from '../../../hooks/utils/useDisplayName';
 import { ContractConnection } from '../../../types';
@@ -113,7 +113,7 @@ export const mapProposalCreatedEventToProposal = async (
   metaData?: ProposalMetaData
 ) => {
   const strategyContract = linearVotingMasterCopyContract.asSigner.attach(strategyAddress);
-  const strategyContractProvider = eventRPC<OZLinearVoting>(
+  const strategyContractProvider = getEventRPC<OZLinearVoting>(
     linearVotingMasterCopyContract,
     chainId
   ).attach(strategyAddress);

--- a/src/providers/Fractal/utils/usul.ts
+++ b/src/providers/Fractal/utils/usul.ts
@@ -4,6 +4,7 @@ import {
   SafeMultisigTransactionResponse,
 } from '@safe-global/safe-service-client';
 import { BigNumber } from 'ethers';
+import { asProper } from '../../../helpers';
 import { logError } from '../../../helpers/errorLogging';
 import { createAccountSubstring } from '../../../hooks/utils/useDisplayName';
 import { ContractConnection } from '../../../types';
@@ -108,10 +109,14 @@ export const mapProposalCreatedEventToProposal = async (
   usulContract: ContractConnection<FractalUsul>,
   linearVotingMasterCopyContract: ContractConnection<OZLinearVoting>,
   provider: Providers,
+  chainId: number,
   metaData?: ProposalMetaData
 ) => {
   const strategyContract = linearVotingMasterCopyContract.asSigner.attach(strategyAddress);
-  const strategyContractProvider = linearVotingMasterCopyContract.asSigner.attach(strategyAddress);
+  const strategyContractProvider = asProper<OZLinearVoting>(
+    linearVotingMasterCopyContract,
+    chainId
+  ).attach(strategyAddress);
   const { deadline, startBlock } = await strategyContract.proposals(proposalNumber);
   const state = await getTxProposalState(
     usulContract,

--- a/src/providers/NetworkConfig/NetworkConfigProvider.tsx
+++ b/src/providers/NetworkConfig/NetworkConfigProvider.tsx
@@ -4,7 +4,6 @@ import { toast } from 'react-toastify';
 import { useDisconnect, useNetwork, useProvider } from 'wagmi';
 import { goerli } from 'wagmi/chains';
 import { goerliConfig } from './networks';
-import { polygonConfig } from './networks/polygon';
 import { NetworkConfig } from './types';
 
 export const defaultState = {
@@ -39,7 +38,7 @@ export const NetworkConfigContext = createContext({} as NetworkConfig);
 export const useNetworkConfg = (): NetworkConfig =>
   useContext(NetworkConfigContext as Context<NetworkConfig>);
 
-export const supportedChains = [goerliConfig, polygonConfig];
+export const supportedChains = [goerliConfig];
 
 const getNetworkConfig = (chainId: number) => {
   if (chainId === 31337) return goerliConfig;

--- a/src/providers/NetworkConfig/NetworkConfigProvider.tsx
+++ b/src/providers/NetworkConfig/NetworkConfigProvider.tsx
@@ -4,6 +4,7 @@ import { toast } from 'react-toastify';
 import { useDisconnect, useNetwork, useProvider } from 'wagmi';
 import { goerli } from 'wagmi/chains';
 import { goerliConfig } from './networks';
+import { polygonConfig } from './networks/polygon';
 import { NetworkConfig } from './types';
 
 export const defaultState = {
@@ -38,7 +39,7 @@ export const NetworkConfigContext = createContext({} as NetworkConfig);
 export const useNetworkConfg = (): NetworkConfig =>
   useContext(NetworkConfigContext as Context<NetworkConfig>);
 
-export const supportedChains = [goerliConfig];
+export const supportedChains = [goerliConfig, polygonConfig];
 
 const getNetworkConfig = (chainId: number) => {
   if (chainId === 31337) return goerliConfig;


### PR DESCRIPTION
## Description

I took what was done in https://github.com/decent-dao/fractal-interface/pull/999 and put those calls into a method that delineates the calls depending on which network you're on.

This way we can bring back polygon, but not rely on the provider for other networks.
