### PR TITLE
Bugfix rpc requests reduction

### DIFF
--- a/src/components/Proposals/UsulDetails/index.tsx
+++ b/src/components/Proposals/UsulDetails/index.tsx
@@ -6,7 +6,6 @@ import { ProposalAction } from '../../../components/Proposals/ProposalActions/Pr
 import ProposalSummary from '../../../components/Proposals/ProposalSummary';
 import ProposalVotes from '../../../components/Proposals/ProposalVotes';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
-import useTokenData from '../../../providers/Fractal/governance/hooks/useGovernanceTokenData';
 import useUpdateProposalState from '../../../providers/Fractal/governance/hooks/useUpdateProposalState';
 import { useFractal } from '../../../providers/Fractal/hooks/useFractal';
 import { TxProposalState, UsulProposal } from '../../../providers/Fractal/types';
@@ -21,13 +20,16 @@ export function UsulProposalDetails({ proposal }: { proposal: UsulProposal }) {
     governance,
     dispatches: { governanceDispatch },
   } = useFractal();
-  const { timeLockPeriod } = useTokenData(governance.contracts);
   const { chainId } = useNetworkConfg();
   const updateProposalState = useUpdateProposalState({ governance, governanceDispatch, chainId });
 
   const { address: account } = useAccount();
 
   useEffect(() => {
+    const timeLockPeriod = governance.governanceToken?.timeLockPeriod;
+    if (!timeLockPeriod) {
+      return;
+    }
     let timeout = 0;
     const now = new Date();
     if (proposal.state === TxProposalState.Active) {
@@ -53,7 +55,6 @@ export function UsulProposalDetails({ proposal }: { proposal: UsulProposal }) {
     };
     // eslint-disable-next-line
   }, [
-    timeLockPeriod,
     proposal.state,
     proposal.proposalNumber,
     proposal.deadline,

--- a/src/components/ui/proposal/ProposalTime.tsx
+++ b/src/components/ui/proposal/ProposalTime.tsx
@@ -4,7 +4,6 @@ import { VetoGuard } from '@fractal-framework/fractal-contracts';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getTxQueuedTimestamp } from '../../../hooks/utils/useSafeActivitiesWithState';
-import useTokenData from '../../../providers/Fractal/governance/hooks/useGovernanceTokenData';
 import { useFractal } from '../../../providers/Fractal/hooks/useFractal';
 import {
   TxProposal,
@@ -24,12 +23,12 @@ function ProposalTime({ proposal }: { proposal: TxProposal }) {
   const [countdownInterval, setCountdownInterval] = useState<NodeJS.Timer>();
   const { t } = useTranslation('proposal');
   const {
-    governance: { contracts },
+    governance,
     gnosis: {
       guardContracts: { vetoGuardContract, vetoGuardType },
     },
   } = useFractal();
-  const { timeLockPeriod } = useTokenData(contracts);
+
   const isActive = proposal.state === TxProposalState.Active;
   const isTimeLocked = proposal.state === TxProposalState.TimeLocked;
   const isQueued = proposal.state === TxProposalState.Queued;
@@ -39,6 +38,11 @@ function ProposalTime({ proposal }: { proposal: TxProposal }) {
   const usulProposal = proposal as UsulProposal;
 
   useEffect(() => {
+    const timeLockPeriod = governance.governanceToken?.timeLockPeriod;
+    if (!timeLockPeriod) {
+      return;
+    }
+
     async function getCountdown() {
       const vetoGuard =
         vetoGuardType === VetoGuardType.MULTISIG
@@ -97,7 +101,6 @@ function ProposalTime({ proposal }: { proposal: TxProposal }) {
     isQueued,
     isExecutable,
     proposal.transaction,
-    timeLockPeriod,
     vetoGuardContract,
     vetoGuardType,
     proposal,


### PR DESCRIPTION
## Description
LFG. This PR makes 3 changes
- removes duplicate use of `useTokenData` hook. replaces with data that is already loaded in state
- removes unneeded dependencies in `useTokenData` useEffects
- adds local caching to `useTokenData` hook
<!-- Please describe your changes -->

## Notes
- This reduces `eth_call` requests by 60-80%!!
- To see the `eth_call` requests you can add the following above in Fractal Provider
```ts
  useEffect(() => {
    const listener = (ev: any) => {
      if (ev.data.data?.data?.method === 'eth_call') {
        console.count('ETH_CALL COUNT');
      }
    };
    window.addEventListener('message', listener);
    return () => {
      window.removeEventListener('message', listener);
    };
  }, []);
  ```

<!-- Is there any additional information a reviewer should know?  -->

## Issue / Notion doc (if applicable)

<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #XXX` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.

New feature work should include a correlating automated integration test via Playwright, in collaboration with the QA team. See this repo's README.md for Playwright setup.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
