### PR TITLE
removes rendering proposals when metadata

### DIFF
--- a/src/pages/ProposalCreate/index.tsx
+++ b/src/pages/ProposalCreate/index.tsx
@@ -8,11 +8,12 @@ import { ProposalDetails } from '../../components/ProposalCreate/ProposalDetails
 import { ProposalHeader } from '../../components/ProposalCreate/ProposalHeader';
 import TransactionsAndSubmit from '../../components/ProposalCreate/TransactionsAndSubmit';
 import UsulMetadata from '../../components/ProposalCreate/UsulMetadata';
+import { BarLoader } from '../../components/ui/loaders/BarLoader';
 import PageHeader from '../../components/ui/page/Header/PageHeader';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../constants/common';
 import useSubmitProposal from '../../hooks/DAO/proposal/useSubmitProposal';
-import useUsul from '../../hooks/DAO/proposal/useUsul';
 import { useFractal } from '../../providers/Fractal/hooks/useFractal';
+import { GovernanceTypes } from '../../providers/Fractal/types';
 import { BASE_ROUTES, DAO_ROUTES } from '../../routes/constants';
 import { ProposalExecuteData } from '../../types/proposal';
 import { TransactionData } from '../../types/transaction';
@@ -37,10 +38,9 @@ const templateAreaSingleCol = `"header"
 function ProposalCreate() {
   const {
     gnosis: { safe },
+    governance: { type },
   } = useFractal();
   const { t } = useTranslation(['proposal', 'common', 'breadcrumbs']);
-  const { usulContract } = useUsul();
-  const [isUsul, setIsUsul] = useState<boolean>();
 
   const [proposalDescription, setProposalDescription] = useState<string>('');
   const [transactions, setTransactions] = useState<TransactionData[]>([
@@ -60,13 +60,9 @@ function ProposalCreate() {
   }>({ title: '', description: '', documentationUrl: '' });
 
   useEffect(() => {
-    setIsUsul(!!usulContract);
-  }, [usulContract]);
-
-  useEffect(() => {
-    if (isUsul === undefined) return;
-    setShowTransactionsAndSubmit(!isUsul || inputtedMetadata);
-  }, [inputtedMetadata, isUsul]);
+    if (!type) return;
+    setShowTransactionsAndSubmit(type !== GovernanceTypes.GNOSIS_SAFE_USUL || inputtedMetadata);
+  }, [inputtedMetadata, type]);
 
   /**
    * adds new transaction form
@@ -150,6 +146,19 @@ function ProposalCreate() {
     return !canUserCreateProposal || !isValidProposal || pendingCreateTx;
   }, [pendingCreateTx, isValidProposal, canUserCreateProposal]);
 
+  if (!type) {
+    return (
+      <Flex
+        minHeight="8.5rem"
+        width="100%"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <BarLoader />
+      </Flex>
+    );
+  }
+
   return (
     <Box>
       <PageHeader
@@ -207,7 +216,7 @@ function ProposalCreate() {
               bg={BACKGROUND_SEMI_TRANSPARENT}
             >
               <ProposalHeader
-                isUsul={isUsul}
+                isUsul={type === GovernanceTypes.GNOSIS_SAFE_USUL}
                 inputtedMetadata={inputtedMetadata}
                 metadataTitle={metadata.title}
                 nonce={nonce}

--- a/src/pages/ProposalCreate/index.tsx
+++ b/src/pages/ProposalCreate/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Text, Grid, GridItem, Box, Flex } from '@chakra-ui/react';
+import { Button, Text, Grid, GridItem, Box, Flex, Center } from '@chakra-ui/react';
 import { Trash } from '@decent-org/fractal-ui';
 import { BigNumber } from 'ethers';
 import { useEffect, useMemo, useState } from 'react';
@@ -10,7 +10,7 @@ import TransactionsAndSubmit from '../../components/ProposalCreate/TransactionsA
 import UsulMetadata from '../../components/ProposalCreate/UsulMetadata';
 import { BarLoader } from '../../components/ui/loaders/BarLoader';
 import PageHeader from '../../components/ui/page/Header/PageHeader';
-import { BACKGROUND_SEMI_TRANSPARENT } from '../../constants/common';
+import { BACKGROUND_SEMI_TRANSPARENT, HEADER_HEIGHT } from '../../constants/common';
 import useSubmitProposal from '../../hooks/DAO/proposal/useSubmitProposal';
 import { useFractal } from '../../providers/Fractal/hooks/useFractal';
 import { GovernanceTypes } from '../../providers/Fractal/types';
@@ -148,14 +148,9 @@ function ProposalCreate() {
 
   if (!type) {
     return (
-      <Flex
-        minHeight="8.5rem"
-        width="100%"
-        alignItems="center"
-        justifyContent="center"
-      >
+      <Center minH={`calc(100vh - ${HEADER_HEIGHT})`}>
         <BarLoader />
-      </Flex>
+      </Center>
     );
   }
 


### PR DESCRIPTION
## Description
I had noticed that when navigating to Create Proposal on Usul DAOs. The Transaction form would flicker before the meta data form shows up. I updated the check slightly to just use the governance type versus the contract. as well as added a BarLoader that shows when type hasn't been set yet
<!-- Please describe your changes -->

## Notes

<!-- Is there any additional information a reviewer should know?  -->

## Issue / Notion doc (if applicable)

<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #XXX` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.

New feature work should include a correlating automated integration test via Playwright, in collaboration with the QA team. See this repo's README.md for Playwright setup.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
