### PR TITLE
Bugfix | node page menu ellipsis spacing

### DIFF
--- a/src/components/ui/cards/DAOInfoCard.tsx
+++ b/src/components/ui/cards/DAOInfoCard.tsx
@@ -56,7 +56,10 @@ export function DAOInfoCard({
   // @todo add viewable conditions
   const canManageDAO = !!account;
   return (
-    <Flex justifyContent="space-between">
+    <Flex
+      justifyContent="space-between"
+      flexGrow={1}
+    >
       <Flex
         alignItems="center"
         flexWrap="wrap"


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

## Notes
Quick fix. Probably from the Mobile refactor? but the `InfoNodeCard` on Node pages had spacing issues with the menu elipsis hugging the DAO name.

One line fix
<!-- Is there any additional information a reviewer should know?  -->

## Issue / Notion doc (if applicable)

<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #XXX` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.

New feature work should include a correlating automated integration test via Playwright, in collaboration with the QA team. See this repo's README.md for Playwright setup.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![localhost_3000_ (43)](https://user-images.githubusercontent.com/38386583/221377598-7f7cf5db-7d10-4609-b0b3-cb0da3b84fee.png)
