### PR TITLE
Temporary Netlify attribution

### DIFF
--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -127,6 +127,18 @@ function Home() {
           {account ? t('homeButtonCreate') : t('homeButtonConnect')}
         </Button>
         <InfoLinks />
+        <Link
+          marginTop="2rem"
+          href="https://www.netlify.com/"
+          isExternal
+        >
+          <Text
+            textStyle="text-md-mono-semibold"
+            color="gold.500"
+          >
+            Deployed by Netlify
+          </Text>
+        </Link>
       </Flex>
     </Center>
   );


### PR DESCRIPTION
## Description

A requirement of applying for a Netlify open source account is to have an attribution to them on your app.

This adds a simple attribution, in order to apply.

We can discuss with @xraystyle1980 later on a better way to attribute Netlify, but I wanted to get this in now to put in the application.

## Screenshots (if applicable)
![Screen Shot 2023-03-07 at 4 02 48 PM](https://user-images.githubusercontent.com/384559/223552663-7b3ef3c7-fff3-468c-96e4-a59a1b12823e.png)