### PR TITLE
Don't init Sentry on prod

### DIFF
--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -1,6 +1,9 @@
 export const notProd = () => {
   return process.env.NODE_ENV !== 'production';
 };
+export const isProd = () => {
+  return process.env.NODE_ENV === 'production';
+};
 
 export const testErrorBoundary = () => {
   const empty: string[] = [];


### PR DESCRIPTION
## Description

Prevents even initializing or calling any Sentry related functions on production builds.