### PR TITLE
Refactor BugFix | Proposal Time refactor

### DIFF
--- a/src/components/Proposals/ProposalActions/Execute.tsx
+++ b/src/components/Proposals/ProposalActions/Execute.tsx
@@ -1,10 +1,7 @@
-import { Text, Button, Flex } from '@chakra-ui/react';
+import { Button } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
-import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
 import useExecuteProposal from '../../../hooks/DAO/proposal/useExecuteProposal';
 import { FractalProposal, FractalProposalState } from '../../../types';
-import ContentBox from '../../ui/containers/ContentBox';
-import ProposalTime from '../../ui/proposal/ProposalTime';
 
 export function Execute({ proposal }: { proposal: FractalProposal }) {
   const { t } = useTranslation(['proposal', 'common']);
@@ -13,19 +10,13 @@ export function Execute({ proposal }: { proposal: FractalProposal }) {
   const disabled = proposal.state !== FractalProposalState.Executing || pending;
 
   return (
-    <ContentBox bg={BACKGROUND_SEMI_TRANSPARENT}>
-      <Flex justifyContent="space-between">
-        <Text textStyle="text-lg-mono-medium">{t('executeTitle')}</Text>
-        <ProposalTime proposal={proposal} />
-      </Flex>
-      <Button
-        onClick={() => executeProposal(proposal)}
-        width="full"
-        isDisabled={disabled}
-        marginTop={5}
-      >
-        {t('execute', { ns: 'common' })}
-      </Button>
-    </ContentBox>
+    <Button
+      onClick={() => executeProposal(proposal)}
+      width="full"
+      isDisabled={disabled}
+      marginTop={5}
+    >
+      {t('execute', { ns: 'common' })}
+    </Button>
   );
 }

--- a/src/components/Proposals/ProposalActions/ProposalAction.tsx
+++ b/src/components/Proposals/ProposalActions/ProposalAction.tsx
@@ -25,7 +25,6 @@ export function ProposalActions({
   proposal: FractalProposal;
   hasVoted: boolean;
 }) {
-  console.log('🚀 ~ file: ProposalActionWrapper.tsx:18 ~ hasVoted:', hasVoted);
   switch (proposal.state) {
     case FractalProposalState.Active:
       return (

--- a/src/components/Proposals/ProposalActions/Queue.tsx
+++ b/src/components/Proposals/ProposalActions/Queue.tsx
@@ -1,11 +1,8 @@
-import { Text, Button, Flex } from '@chakra-ui/react';
+import { Button } from '@chakra-ui/react';
 import { BigNumber } from 'ethers';
 import { useTranslation } from 'react-i18next';
-import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
 import useQueueProposal from '../../../hooks/DAO/proposal/useQueueProposal';
 import { FractalProposal, FractalProposalState } from '../../../types';
-import ContentBox from '../../ui/containers/ContentBox';
-import ProposalTime from '../../ui/proposal/ProposalTime';
 
 export default function Queue({ proposal }: { proposal: FractalProposal }) {
   const { t } = useTranslation(['proposal', 'common']);
@@ -14,19 +11,13 @@ export default function Queue({ proposal }: { proposal: FractalProposal }) {
   const disabled = pending || proposal.state !== FractalProposalState.Queueable;
 
   return (
-    <ContentBox bg={BACKGROUND_SEMI_TRANSPARENT}>
-      <Flex justifyContent="space-between">
-        <Text textStyle="text-lg-mono-medium">{t('queueTitle')}</Text>
-        <ProposalTime proposal={proposal} />
-      </Flex>
-      <Button
-        width="full"
-        isDisabled={disabled}
-        marginTop={5}
-        onClick={() => queueProposal(BigNumber.from(proposal.proposalNumber))}
-      >
-        {t('queue', { ns: 'common' })}
-      </Button>
-    </ContentBox>
+    <Button
+      width="full"
+      isDisabled={disabled}
+      marginTop={5}
+      onClick={() => queueProposal(BigNumber.from(proposal.proposalNumber))}
+    >
+      {t('queue', { ns: 'common' })}
+    </Button>
   );
 }

--- a/src/components/Proposals/ProposalActions/Vote.tsx
+++ b/src/components/Proposals/ProposalActions/Vote.tsx
@@ -1,10 +1,9 @@
-import { Text, Button, Flex, Tooltip } from '@chakra-ui/react';
+import { Button, Tooltip } from '@chakra-ui/react';
 import { CloseX, Check } from '@decent-org/fractal-ui';
 import { BigNumber } from 'ethers';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAccount } from 'wagmi';
-import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
 import useCastVote from '../../../hooks/DAO/proposal/useCastVote';
 import useCurrentBlockNumber from '../../../hooks/utils/useCurrentBlockNumber';
 import { useFractal } from '../../../providers/App/AppProvider';
@@ -15,9 +14,6 @@ import {
   UsulVoteChoice,
   AzoriusGovernance,
 } from '../../../types';
-
-import ContentBox from '../../ui/containers/ContentBox';
-import ProposalTime from '../../ui/proposal/ProposalTime';
 
 function Vote({
   proposal,
@@ -74,11 +70,7 @@ function Vote({
           : undefined
       }
     >
-      <ContentBox bg={BACKGROUND_SEMI_TRANSPARENT}>
-        <Flex justifyContent="space-between">
-          <Text textStyle="text-lg-mono-medium">{t('vote')}</Text>
-          <ProposalTime proposal={proposal} />
-        </Flex>
+      <>
         <Button
           width="full"
           isDisabled={disabled}
@@ -105,7 +97,7 @@ function Vote({
         >
           {t('abstain')}
         </Button>
-      </ContentBox>
+      </>
     </Tooltip>
   );
 }

--- a/src/components/pages/DAOTreasury/hooks/useSendAssets.ts
+++ b/src/components/pages/DAOTreasury/hooks/useSendAssets.ts
@@ -2,6 +2,7 @@ import { SafeBalanceUsdResponse } from '@safe-global/safe-service-client';
 import { BigNumber, ethers } from 'ethers';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDAOProposals } from '../../../../hooks/DAO/loaders/useProposals';
 import useSubmitProposal from '../../../../hooks/DAO/proposal/useSubmitProposal';
 import { ProposalExecuteData } from '../../../../types';
 import { formatCoin } from '../../../../utils/numberFormats';
@@ -18,6 +19,7 @@ const useSendAssets = ({
   nonce: number | undefined;
 }) => {
   const { submitProposal } = useSubmitProposal();
+  const loadDAOProposals = useDAOProposals();
   const { t } = useTranslation(['modals', 'proposalMetadata']);
 
   const sendAssets = useCallback(() => {
@@ -49,6 +51,9 @@ const useSendAssets = ({
     submitProposal({
       proposalData,
       nonce,
+      successCallback: async () => {
+        await loadDAOProposals();
+      },
       pendingToastMessage: t('sendAssetsPendingToastMessage'),
       successToastMessage: t('sendAssetsSuccessToastMessage'),
       failedToastMessage: t('sendAssetsFailureToastMessage'),
@@ -60,6 +65,7 @@ const useSendAssets = ({
     transferAmount,
     destinationAddress,
     t,
+    loadDAOProposals,
     submitProposal,
     nonce,
   ]);

--- a/src/components/ui/proposal/ProposalTime.tsx
+++ b/src/components/ui/proposal/ProposalTime.tsx
@@ -202,8 +202,10 @@ function ProposalTime({ proposal }: { proposal: FractalProposal }) {
             color="chocolate.200"
             textStyle="text-base-mono-semibold"
           >
-            {zeroPad(daysLeft, 2)}:{zeroPad(hoursLeft, 2)}:{zeroPad(minutesLeft, 2)}:
-            {zeroPad(secondsLeft, 2)}
+            {daysLeft > 0 && `${zeroPad(daysLeft, 2)}:`}
+            {hoursLeft > 0 && `${zeroPad(hoursLeft, 2)}:`}
+            {minutesLeft > 0 && `${zeroPad(minutesLeft, 2)}:`}
+            {secondsLeft > 0 && `${zeroPad(secondsLeft, 2)}`}
           </Text>
         </Flex>
       </Flex>

--- a/src/components/ui/proposal/ProposalTime.tsx
+++ b/src/components/ui/proposal/ProposalTime.tsx
@@ -76,7 +76,6 @@ function useCountdown(proposal: FractalProposal) {
     };
 
     const startCountdown = (initialTime: number, intervalTime: number) => {
-      updateCountdown(initialTime);
       countdownInterval = setInterval(() => {
         updateCountdown(initialTime - Date.now());
       }, intervalTime);
@@ -180,6 +179,7 @@ function ProposalTime({ proposal }: { proposal: FractalProposal }) {
   }
 
   const zeroPad = (num: number, places: number) => String(num).padStart(places, '0');
+  const daysLeft = Math.floor(countdown / (1000 * 60 * 60 * 24));
   const hoursLeft = Math.floor(countdown / (1000 * 60 * 60));
   const minutesLeft = Math.floor((countdown / (60 * 1000)) % 60);
   const secondsLeft = Math.floor((countdown / 1000) % 60);
@@ -202,7 +202,8 @@ function ProposalTime({ proposal }: { proposal: FractalProposal }) {
             color="chocolate.200"
             textStyle="text-base-mono-semibold"
           >
-            {zeroPad(hoursLeft, 2)}:{zeroPad(minutesLeft, 2)}:{zeroPad(secondsLeft, 2)}
+            {zeroPad(daysLeft, 2)}:{zeroPad(hoursLeft, 2)}:{zeroPad(minutesLeft, 2)}:
+            {zeroPad(secondsLeft, 2)}
           </Text>
         </Flex>
       </Flex>

--- a/src/components/ui/proposal/ProposalTime.tsx
+++ b/src/components/ui/proposal/ProposalTime.tsx
@@ -1,8 +1,11 @@
 import { Flex, Text, Tooltip } from '@chakra-ui/react';
 import { Vote, Execute, Lock } from '@decent-org/fractal-ui';
 import { VetoGuard } from '@fractal-framework/fractal-contracts';
-import { useEffect, useMemo, useState } from 'react';
+import { BigNumber } from 'ethers';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useProvider } from 'wagmi';
+import useUpdateProposalState from '../../../hooks/DAO/proposal/useUpdateProposalState';
 import { getTxQueuedTimestamp } from '../../../hooks/utils/useSafeActivitiesWithState';
 import { useFractal } from '../../../providers/App/AppProvider';
 import {
@@ -19,67 +22,94 @@ const ICONS_MAP = {
   execute: Execute,
 };
 
-function ProposalTime({ proposal }: { proposal: FractalProposal }) {
+function useCountdown(proposal: FractalProposal) {
   const [countdown, setCountdown] = useState<number>();
-  const [countdownInterval, setCountdownInterval] = useState<NodeJS.Timer>();
-  const { t } = useTranslation('proposal');
   const {
     governance,
     guardContracts: { vetoGuardContract, vetoGuardType },
+    governanceContracts,
+    dispatch,
   } = useFractal();
-
-  const isActive = useMemo(() => proposal.state === FractalProposalState.Active, [proposal]);
-  const isTimeLocked = useMemo(
-    () => proposal.state === FractalProposalState.TimeLocked,
-    [proposal]
-  );
-  const isQueued = useMemo(() => proposal.state === FractalProposalState.Queued, [proposal]);
-  const isExecutable = useMemo(() => proposal.state === FractalProposalState.Executing, [proposal]);
-  const showCountdown = useMemo(
-    () => isActive || isTimeLocked || isExecutable || isQueued,
-    [isActive, isTimeLocked, isExecutable, isQueued]
-  );
-
+  const {
+    network: { chainId },
+  } = useProvider();
   const usulProposal = proposal as UsulProposal;
   const azoriusGovernance = governance as AzoriusGovernance;
+  const updateProposalState = useUpdateProposalState({
+    governanceContracts,
+    governanceDispatch: dispatch.governance,
+    chainId,
+  });
+
+  let updateStateInterval = useRef<NodeJS.Timer | undefined>();
   useEffect(() => {
-    const timeLockPeriod = azoriusGovernance.votesStrategy?.timeLockPeriod;
-    if (!timeLockPeriod) {
+    if (proposal.state === FractalProposalState.Executing) {
+      clearInterval(updateStateInterval.current);
       return;
     }
+    if (countdown && countdown < 0 && !updateStateInterval.current) {
+      updateStateInterval.current = setInterval(() => {
+        // Wrap the updateProposalState call in an async IIFE
+        (async () => {
+          try {
+            await updateProposalState(BigNumber.from(proposal.proposalNumber));
+          } catch (error) {
+            console.error('Error updating proposal state:', error);
+          }
+        })();
+      }, 10000);
+    } else if (countdown && countdown > 0 && updateStateInterval.current) {
+      clearInterval(updateStateInterval.current);
+      updateStateInterval.current = undefined;
+    }
+    return () => {
+      if (updateStateInterval.current && !countdown) {
+        clearInterval(updateStateInterval.current);
+      }
+    };
+  }, [countdown, updateProposalState, proposal]);
+
+  useEffect(() => {
+    let countdownInterval: NodeJS.Timer | undefined;
+    const updateCountdown = (time: number) => {
+      setCountdown(time);
+    };
+
+    const startCountdown = (initialTime: number, intervalTime: number) => {
+      updateCountdown(initialTime);
+      countdownInterval = setInterval(() => {
+        updateCountdown(initialTime - Date.now());
+      }, intervalTime);
+    };
 
     async function getCountdown() {
+      const timeLockPeriod = azoriusGovernance.votesStrategy?.timeLockPeriod;
+      if (!timeLockPeriod) {
+        return;
+      }
+
       const vetoGuard =
         vetoGuardType === VetoGuardType.MULTISIG
           ? (vetoGuardContract?.asSigner as VetoGuard)
           : undefined;
 
-      if (isActive && usulProposal.deadline) {
-        const interval = setInterval(() => {
-          setCountdown(usulProposal.deadline * 1000 - Date.now());
-        }, 1000);
-        setCountdownInterval(interval);
-      } else if (isTimeLocked && usulProposal.deadline && timeLockPeriod) {
-        const interval = setInterval(() => {
-          setCountdown((usulProposal.deadline + Number(timeLockPeriod.value)) * 1000 - Date.now());
-        }, 1000);
-        setCountdownInterval(interval);
-      } else if (isQueued && vetoGuard) {
+      if (proposal.state === FractalProposalState.Active && usulProposal.deadline) {
+        startCountdown(usulProposal.deadline * 1000, 1000);
+      } else if (
+        proposal.state === FractalProposalState.TimeLocked &&
+        usulProposal.deadline &&
+        timeLockPeriod
+      ) {
+        startCountdown((usulProposal.deadline + Number(timeLockPeriod.value)) * 1000, 1000);
+      } else if (proposal.state === FractalProposalState.Queued && vetoGuard) {
         const queuedTimestamp = await getTxQueuedTimestamp(proposal, vetoGuard);
         const guardTimeLockPeriod = (await vetoGuard.timelockPeriod()).toNumber();
-        const interval = setInterval(() => {
-          setCountdown(queuedTimestamp + guardTimeLockPeriod - Date.now());
-        }, 1000);
-        setCountdownInterval(interval);
-      } else if (isExecutable && vetoGuard) {
+        startCountdown(queuedTimestamp + guardTimeLockPeriod, 1000);
+      } else if (proposal.state === FractalProposalState.Executing && vetoGuard) {
         const queuedTimestamp = await getTxQueuedTimestamp(proposal, vetoGuard);
         const guardTimeLockPeriod = (await vetoGuard.timelockPeriod()).toNumber();
         const guardExecutionPeriod = (await vetoGuard.executionPeriod()).toNumber();
-
-        const interval = setInterval(() => {
-          setCountdown(queuedTimestamp + guardTimeLockPeriod + guardExecutionPeriod - Date.now());
-        }, 1000);
-        setCountdownInterval(interval);
+        startCountdown(queuedTimestamp + guardTimeLockPeriod + guardExecutionPeriod, 1000);
       }
     }
 
@@ -93,15 +123,34 @@ function ProposalTime({ proposal }: { proposal: FractalProposal }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     usulProposal.deadline,
-    isActive,
-    isTimeLocked,
-    isQueued,
-    isExecutable,
-    proposal.transaction,
+    proposal.state,
+    azoriusGovernance.votesStrategy,
     vetoGuardContract,
     vetoGuardType,
-    proposal,
+    proposal.state,
+    azoriusGovernance.votesStrategy,
+    vetoGuardContract,
+    vetoGuardType,
   ]);
+
+  return countdown;
+}
+
+function ProposalTime({ proposal }: { proposal: FractalProposal }) {
+  const countdown = useCountdown(proposal);
+  const { t } = useTranslation('proposal');
+
+  const isActive = useMemo(() => proposal.state === FractalProposalState.Active, [proposal]);
+  const isTimeLocked = useMemo(
+    () => proposal.state === FractalProposalState.TimeLocked,
+    [proposal]
+  );
+  const isQueued = useMemo(() => proposal.state === FractalProposalState.Queued, [proposal]);
+  const isExecutable = useMemo(() => proposal.state === FractalProposalState.Executing, [proposal]);
+  const showCountdown = useMemo(
+    () => isActive || isTimeLocked || isExecutable || isQueued,
+    [isActive, isTimeLocked, isExecutable, isQueued]
+  );
 
   const tooltipLabel = t(
     isActive
@@ -130,8 +179,6 @@ function ProposalTime({ proposal }: { proposal: FractalProposal }) {
     return null;
   }
 
-  // Unfortunately, date-fns don't have anything handy for our countdown display format
-  // So, have to do it manually
   const zeroPad = (num: number, places: number) => String(num).padStart(places, '0');
   const hoursLeft = Math.floor(countdown / (1000 * 60 * 60));
   const minutesLeft = Math.floor((countdown / (60 * 1000)) % 60);

--- a/src/hooks/DAO/proposal/useUpdateProposalState.ts
+++ b/src/hooks/DAO/proposal/useUpdateProposalState.ts
@@ -29,7 +29,6 @@ export default function useUpdateProposalState({
         proposalNumber,
         chainId
       );
-
       governanceDispatch({
         type: FractalGovernanceAction.UPDATE_PROPOSAL_STATE,
         payload: { proposalNumber: proposalNumber.toString(), state: newState },


### PR DESCRIPTION
## Description
This PR addresses some of the timer-related issues in our proposal system, focusing on providing better feedback to the user about the current proposal state

There are two remaining periods where either we could improve our timer's accuracy or add some kinda of indiction of 'why' its not ready yet.

- Period after voting period ends for roughly 1-2 block time before voting period ends
- Period after queuing where execution is unavailable for some time. 

This new setup will call `updateTxState` when the timer goes negative on a set interval. I currently have this set at 10 seconds, a little less than 1 block. 
<!-- Please describe your changes -->

## Notes
This PR also adds 'days' to timer. pending response in chat
<!-- Is there any additional information a reviewer should know?  -->

## Issue / Notion doc (if applicable)
Closes #1051 
Closes #1045
<!-----------------------------------------------------------------------------
If applicable, link to the relevant Github issue(s) with `closes #XXX` to auto-close it when this PR is merged.

If there is an accompanying Notion document, please link that here as well.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.

New feature work should include a correlating automated integration test via Playwright, in collaboration with the QA team. See this repo's README.md for Playwright setup.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
