### PR TITLE
fix 1password appearing in address inputs

### DIFF
--- a/src/components/DaoCreator/formComponents/AzoriusTokenAllocation.tsx
+++ b/src/components/DaoCreator/formComponents/AzoriusTokenAllocation.tsx
@@ -1,9 +1,10 @@
-import { Input, IconButton, Box } from '@chakra-ui/react';
+import { IconButton, Box } from '@chakra-ui/react';
 import { LabelWrapper, Trash } from '@decent-org/fractal-ui';
 import { BigNumber } from 'ethers';
 import { Field, FieldAttributes } from 'formik';
 import { useFormHelpers } from '../../../hooks/utils/useFormHelpers';
 import { BigNumberInput } from '../../ui/forms/BigNumberInput';
+import { AddressInput } from '../../ui/forms/EthAddressInput';
 interface ITokenAllocations {
   index: number;
   remove: <T>(index: number) => T | undefined;
@@ -30,9 +31,8 @@ export function AzoriusTokenAllocation({
       <LabelWrapper errorMessage={addressErrorMessage}>
         <Field name={`govToken.tokenAllocations.${index}.address`}>
           {({ field }: FieldAttributes<any>) => (
-            <Input
+            <AddressInput
               {...field}
-              placeholder="0x0000...0000"
               data-testid={'tokenVoting-tokenAllocationAddressInput-' + index}
             />
           )}

--- a/src/components/DaoCreator/formComponents/GnosisMultisig.tsx
+++ b/src/components/DaoCreator/formComponents/GnosisMultisig.tsx
@@ -4,7 +4,6 @@ import {
   Flex,
   Grid,
   IconButton,
-  Input,
   NumberInput,
   NumberInputField,
 } from '@chakra-ui/react';
@@ -14,6 +13,7 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFormHelpers } from '../../../hooks/utils/useFormHelpers';
 import { ICreationStepProps, CreatorSteps } from '../../../types';
+import { AddressInput } from '../../ui/forms/EthAddressInput';
 import { LabelComponent } from '../../ui/forms/InputComponent';
 import { StepButtons } from '../StepButtons';
 import { StepWrapper } from '../StepWrapper';
@@ -136,9 +136,8 @@ export function GnosisMultisig(props: ICreationStepProps) {
                   >
                     <Field name={`gnosis.trustedAddresses.${i}`}>
                       {({ field }: FieldAttributes<any>) => (
-                        <Input
+                        <AddressInput
                           {...field}
-                          placeholder="0x0000...0000"
                           data-testid={'gnosisConfig-signer-' + i}
                         />
                       )}

--- a/src/components/pages/ManageSigners/AddSignerModal.tsx
+++ b/src/components/pages/ManageSigners/AddSignerModal.tsx
@@ -6,7 +6,6 @@ import {
   HStack,
   Select,
   Text,
-  Input,
   Alert,
   AlertTitle,
   Image,
@@ -22,6 +21,7 @@ import useDefaultNonce from '../../../hooks/DAO/useDefaultNonce';
 import { useValidationAddress } from '../../../hooks/schemas/common/useValidationAddress';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { CustomNonceInput } from '../../ui/forms/CustomNonceInput';
+import { AddressInput } from '../../ui/forms/EthAddressInput';
 import ModalTooltip from '../../ui/modals/ModalTooltip';
 import useAddSigner from './hooks/useAddSigner';
 
@@ -102,10 +102,7 @@ function AddSignerModal({
                   subLabel={t('addSignerSublabel', { ns: 'modals' })}
                   errorMessage={field.value && errors.address}
                 >
-                  <Input
-                    placeholder="0x0000...0000"
-                    {...field}
-                  />
+                  <AddressInput {...field} />
                 </LabelWrapper>
               )}
             </Field>

--- a/src/components/ui/forms/EthAddressInput.tsx
+++ b/src/components/ui/forms/EthAddressInput.tsx
@@ -1,7 +1,13 @@
-import { InputElementProps, FormControlOptions, Input } from '@chakra-ui/react';
+import { InputElementProps, FormControlOptions, Input, InputProps } from '@chakra-ui/react';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { useValidationAddress } from '../../../hooks/schemas/common/useValidationAddress';
 import useAddress from '../../../hooks/utils/useAddress';
 
+/**
+ * @deprecated we've replaced this component with validation via Yup
+ * in {@link useValidationAddress}.
+ */
 export interface EthAddressInputProps
   extends Omit<InputElementProps, 'onChange' | 'placeholder' | 'type'>,
     FormControlOptions {
@@ -11,9 +17,8 @@ export interface EthAddressInputProps
 }
 
 /**
- * @param value an optional stateful string value, if you'd like to have access to this outside this component
- * @param setValue the corresponding setter for the value parameter, both are required for either to be used
- * @param onAddressChange a callback that provides the current address, along with whether it is valid
+ * @deprecated we've replaced this component with validation via Yup
+ * in {@link useValidationAddress}.
  */
 export function EthAddressInput({
   value,
@@ -47,6 +52,23 @@ export function EthAddressInput({
         }
         setActualInputValue(event.target.value.trim());
       }}
+      {...rest}
+    />
+  );
+}
+
+/**
+ * A simple Input for Ethereum addresses. Input validation is provided via Yup
+ * in {@link useValidationAddress}
+ */
+export function AddressInput({ ...rest }: InputProps) {
+  return (
+    <Input
+      // preface id with "search" to prevent showing 1password
+      // https://1password.community/discussion/comment/606453/#Comment_606453
+      id="searchButActuallyEthAddress"
+      autoComplete="off"
+      placeholder="0x0000...0000"
       {...rest}
     />
   );

--- a/src/components/ui/modals/DelegateModal.tsx
+++ b/src/components/ui/modals/DelegateModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Divider, Flex, Input, SimpleGrid, Spacer, Text } from '@chakra-ui/react';
+import { Box, Button, Divider, Flex, SimpleGrid, Spacer, Text } from '@chakra-ui/react';
 import { LabelWrapper } from '@decent-org/fractal-ui';
 import { BigNumber, constants } from 'ethers';
 import { Field, FieldAttributes, Formik } from 'formik';
@@ -11,6 +11,7 @@ import useDisplayName from '../../../hooks/utils/useDisplayName';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { AzoriusGovernance } from '../../../types';
 import { formatCoin } from '../../../utils/numberFormats';
+import { AddressInput } from '../forms/EthAddressInput';
 import EtherscanLinkAddress from '../links/EtherscanLinkAddress';
 
 export function DelegateModal({ close }: { close: Function }) {
@@ -140,9 +141,8 @@ export function DelegateModal({ close }: { close: Function }) {
                   subLabel={t('sublabelDelegateInput')}
                   errorMessage={errors.address}
                 >
-                  <Input
+                  <AddressInput
                     data-testid="delegate-addressInput"
-                    placeholder="0x0000...0000"
                     {...field}
                   />
                 </LabelWrapper>


### PR DESCRIPTION
## Description

Fixes 1password appearing in address inputs by providing a new "AddressInput" Input extension.

## Issue / Notion doc (if applicable)

closes https://github.com/decent-dao/fractal-interface/issues/1116

## Testing

Please check the token allocation modal to ensure the input still works correctly.