### PR TITLE
Add |  Max button on inputs

### DIFF
--- a/src/components/ui/forms/BigNumberInput.tsx
+++ b/src/components/ui/forms/BigNumberInput.tsx
@@ -1,8 +1,15 @@
-import { FormControlOptions, Input, InputElementProps } from '@chakra-ui/react';
+import {
+  FormControlOptions,
+  Input,
+  InputGroup,
+  InputElementProps,
+  InputRightElement,
+  Button,
+} from '@chakra-ui/react';
 import { utils, BigNumber, constants } from 'ethers';
 import { useState, useCallback, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { BigNumberValuePair } from '../../../types';
-
 export interface BigNumberInputProps
   extends Omit<InputElementProps, 'value' | 'onChange'>,
     FormControlOptions {
@@ -11,6 +18,7 @@ export interface BigNumberInputProps
   decimalPlaces?: number;
   min?: string;
   max?: string;
+  maxValue?: BigNumber;
 }
 /**
  * This component will add a chakra Input component that accepts and sets a BigNumber
@@ -20,6 +28,7 @@ export interface BigNumberInputProps
  * @param decimalPlaces number of decimal places to be used to parse the value to set the BigNumber
  * @param min Setting a minimum value will reset the Input value to min when the component's focus is lost. Can set decimal number for minimum, but must respect the decimalPlaces value.
  * @param max Setting this will cause the value of the Input control to be reset to the maximum when a number larger than it is inputted.
+ * @param maxValue The maximum value that can be inputted. This is used to set the max value of the Input control.
  * @parma ...rest component accepts all properties for Input and FormControl
  * @returns
  */
@@ -29,8 +38,10 @@ export function BigNumberInput({
   decimalPlaces = 18,
   min,
   max,
+  maxValue,
   ...rest
 }: BigNumberInputProps) {
+  const { t } = useTranslation('common');
   const removeTrailingZeros = (input: string) => {
     if (input.includes('.')) {
       const [leftDigits, rightDigits] = input.split('.');
@@ -159,11 +170,32 @@ export function BigNumberInput({
   }, [decimalPlaces]);
 
   return (
-    <Input
-      value={inputValue}
-      onChange={onChangeInput}
-      onBlur={onBlur}
-      {...rest}
-    />
+    <InputGroup>
+      <Input
+        value={inputValue}
+        onChange={onChangeInput}
+        onBlur={onBlur}
+        {...rest}
+      />
+      {maxValue && (
+        <InputRightElement width="4.5rem">
+          <Button
+            h="1.75rem"
+            onClick={() => {
+              const newValue = {
+                value: truncateDecimalPlaces(utils.formatUnits(maxValue, decimalPlaces)),
+                bigNumberValue: maxValue,
+              };
+              setInputValue(newValue.value);
+              onChange(newValue);
+            }}
+            variant="text"
+            size="md"
+          >
+            {t('max')}
+          </Button>
+        </InputRightElement>
+      )}
+    </InputGroup>
   );
 }

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -116,6 +116,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
             onChange={onChangeAmount}
             decimalPlaces={selectedAsset?.token?.decimals}
             placeholder="0"
+            maxValue={BigNumber.from(selectedAsset.balance)}
           />
         </Box>
       </Flex>

--- a/src/components/ui/modals/UnwrapToken.tsx
+++ b/src/components/ui/modals/UnwrapToken.tsx
@@ -128,6 +128,7 @@ export function UnwrapToken({ close }: { close: () => void }) {
                   onChange={valuePair => setFieldValue('amount', valuePair)}
                   data-testid="unWrapToken-amount"
                   onKeyDown={restrictChars}
+                  maxValue={azoriusGovernance.votesToken.balance!}
                   isDisabled={!approved}
                 />
               </LabelWrapper>

--- a/src/components/ui/modals/WrapToken.tsx
+++ b/src/components/ui/modals/WrapToken.tsx
@@ -1,6 +1,6 @@
-import { Button, Flex, Input, InputGroup, InputRightElement } from '@chakra-ui/react';
+import { Button, Flex, Input } from '@chakra-ui/react';
 import { LabelWrapper } from '@decent-org/fractal-ui';
-import { BigNumber, Contract, utils } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 import { Formik, FormikProps } from 'formik';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/ui/modals/WrapToken.tsx
+++ b/src/components/ui/modals/WrapToken.tsx
@@ -1,6 +1,6 @@
-import { Button, Flex, Input } from '@chakra-ui/react';
+import { Button, Flex, Input, InputGroup, InputRightElement } from '@chakra-ui/react';
 import { LabelWrapper } from '@decent-org/fractal-ui';
-import { BigNumber, Contract } from 'ethers';
+import { BigNumber, Contract, utils } from 'ethers';
 import { Formik, FormikProps } from 'formik';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -163,6 +163,7 @@ export function WrapToken({ close }: { close: () => void }) {
                   onChange={valuePair => setFieldValue('amount', valuePair)}
                   data-testid="wrapToken-amount"
                   onKeyDown={restrictChars}
+                  maxValue={userBalance.bigNumberValue}
                 />
               </LabelWrapper>
 

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -85,5 +85,6 @@
     "settings": "Settings",
     "etherscanTip": "Open in Etherscan",
     "wrapToken": "Wrap Token",
-    "unwrapToken": "Unwrap Token"
+    "unwrapToken": "Unwrap Token",
+    "max": "max"
 }


### PR DESCRIPTION
## Description

This PR adds a "Max" button to the `BigNumberInput` component used in the `WrapToken`, `UnwrapToken`, and `Send Assets` modals. The button appears only when the `maxValue` prop is passed to the component. When clicked, the input value is set to the user's balance or the provided maximum value.

## Notes

- Added a `maxValue` prop to the `BigNumberInput` component to control the display of the "Max" button and set the maximum value for the input.
- Updated the `WrapToken`, `UnwrapToken`, and `Send Assets` modals to pass the user's balance or the maximum value to the `BigNumberInput` component.

## Issue / Notion doc (if applicable)

Fixes #1122

## Testing

1. Navigate to the `WrapToken`, `UnwrapToken`, and `Send Assets` modals.
2. Ensure the "Max" button appears when the `maxValue` prop is passed to the `BigNumberInput` component.
3. Click the "Max" button and verify that the input value is set to the user's balance or the provided maximum value.

## Screenshots (if applicable)
![localhost_3000_daos_0x34fcCd709645e12E71279DcB3CA7bf695eB9C075_treasury(Desktop) (2)](https://user-images.githubusercontent.com/38386583/235272163-5afc0d00-2dbf-4e5b-a2d9-a1dab88e6b32.png)

![localhost_3000_daos_0x34fcCd709645e12E71279DcB3CA7bf695eB9C075_treasury(Desktop) (1)](https://user-images.githubusercontent.com/38386583/235272164-1f4acbb6-42cb-408c-856d-3a7d4b34f145.png)

![localhost_3000_daos_0x34fcCd709645e12E71279DcB3CA7bf695eB9C075_treasury(Desktop)](https://user-images.githubusercontent.com/38386583/235272167-0ff2def1-119c-4cf0-89db-ef63e2069073.png)

