### PR TITLE
BugFix | updates number of signers input for better UX

### DIFF
--- a/src/components/DaoCreator/formComponents/GnosisMultisig.tsx
+++ b/src/components/DaoCreator/formComponents/GnosisMultisig.tsx
@@ -10,7 +10,6 @@ import {
 } from '@chakra-ui/react';
 import { LabelWrapper, Trash } from '@decent-org/fractal-ui';
 import { Field, FieldAttributes } from 'formik';
-import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFormHelpers } from '../../../hooks/utils/useFormHelpers';
 import { ICreationStepProps, CreatorSteps } from '../../../types';
@@ -20,58 +19,48 @@ import { StepWrapper } from '../StepWrapper';
 
 export function GnosisMultisig(props: ICreationStepProps) {
   const { t } = useTranslation(['daoCreate']);
-  const {
-    values,
-    errors,
-    setFieldValue,
-    isSubmitting,
-    transactionPending,
-    isSubDAO,
-    validateForm,
-    setErrors,
-  } = props;
+  const { values, errors, setFieldValue, isSubmitting, transactionPending, isSubDAO } = props;
   const { restrictChars } = useFormHelpers();
 
-  const handleSignersChanges = (_: string, numberStr: number, index?: number) => {
-    let numOfSigners = Number(numberStr || 0);
-    // greater than 99 signers is unreasonable for manual input here,
-    // we don't use an error message because we don't want to render
-    // 1000 input fields and lag the app
-    if (numOfSigners > 99) {
-      numOfSigners = 99;
-    }
-    const gnosisAddresses = [...values.gnosis.trustedAddresses];
-    const trustedAddressLength = gnosisAddresses.length;
-    if (trustedAddressLength !== numOfSigners) {
-      if (!numOfSigners || numOfSigners < 1) {
-        numOfSigners = 1;
-      }
-      if (numOfSigners > trustedAddressLength) {
-        const difference = numOfSigners - trustedAddressLength;
-        gnosisAddresses.push(...new Array(difference).fill(''));
-      }
-      if (numOfSigners < trustedAddressLength) {
-        const difference = trustedAddressLength - numOfSigners;
-        if (index !== undefined) {
-          gnosisAddresses.splice(index, 1);
-        } else {
-          gnosisAddresses.splice(trustedAddressLength - difference, difference + 1);
-        }
-      }
-      if (gnosisAddresses.length) {
-        setFieldValue('gnosis.trustedAddresses', gnosisAddresses);
-      }
-    }
-    setFieldValue('gnosis.numOfSigners', numOfSigners);
+  const truncateSignersList = (gnosisAddresses: string[], numOfSigners: number) => {
+    const difference = gnosisAddresses.length - numOfSigners;
+    return gnosisAddresses.slice(0, gnosisAddresses.length - difference);
   };
 
-  useEffect(() => {
-    if (values.gnosis.numOfSigners !== values.gnosis.trustedAddresses.length) {
-      (async () => {
-        setErrors(await validateForm(values));
-      })();
+  const appendEmptySigners = (gnosisAddresses: string[], numOfSigners: number) => {
+    const difference = numOfSigners - gnosisAddresses.length;
+    return gnosisAddresses.concat(new Array(difference).fill(''));
+  };
+
+  const handleSignersChanges = (
+    gnosisAddresses: string[],
+    numOfSigners?: number,
+    index?: number
+  ) => {
+    if (numOfSigners === undefined) {
+      setFieldValue('gnosis.numOfSigners', numOfSigners);
     }
-  }, [values, validateForm, setErrors]);
+
+    numOfSigners = Math.min(numOfSigners || 0, 99);
+    const trustedAddressLength = gnosisAddresses.length;
+
+    if (numOfSigners && trustedAddressLength !== numOfSigners) {
+      gnosisAddresses =
+        numOfSigners > trustedAddressLength
+          ? appendEmptySigners(gnosisAddresses, numOfSigners)
+          : truncateSignersList(gnosisAddresses, numOfSigners);
+
+      if (index !== undefined) {
+        gnosisAddresses.splice(index, 1);
+      }
+    }
+
+    setFieldValue('gnosis', {
+      ...values.gnosis,
+      numOfSigners: numOfSigners,
+      trustedAddresses: gnosisAddresses,
+    });
+  };
 
   return (
     <StepWrapper
@@ -90,8 +79,9 @@ export function GnosisMultisig(props: ICreationStepProps) {
         >
           <NumberInput
             value={values.gnosis.numOfSigners}
-            min={1}
-            onChange={(inputStr, inputNum) => handleSignersChanges(inputStr, inputNum)}
+            onChange={(_, inputNum) =>
+              handleSignersChanges(values.gnosis.trustedAddresses, inputNum)
+            }
             onKeyDown={restrictChars}
           >
             <NumberInputField data-testid="gnosisConfig-numberOfSignerInput" />
@@ -156,7 +146,11 @@ export function GnosisMultisig(props: ICreationStepProps) {
                         }
                         type="button"
                         onClick={async () => {
-                          handleSignersChanges('', --values.gnosis.numOfSigners, i);
+                          handleSignersChanges(
+                            values.gnosis.trustedAddresses,
+                            --values.gnosis.numOfSigners!,
+                            i
+                          );
                         }}
                         data-testid={'gnosis.numOfSigners-' + i}
                       />

--- a/src/hooks/schemas/DAOCreate/useDAOCreateSchema.ts
+++ b/src/hooks/schemas/DAOCreate/useDAOCreateSchema.ts
@@ -45,8 +45,10 @@ export const useDAOCreateSchema = ({ isSubDAO }: { isSubDAO?: boolean }) => {
               signatureThreshold: Yup.number()
                 .min(1, t('errorLowSignerThreshold'))
                 .max(Yup.ref('numOfSigners'), t('errorHighSignerThreshold'))
-                .required(),
-              numOfSigners: Yup.number().min(1),
+                .required(t('errorHighSignerThreshold')),
+              numOfSigners: Yup.number()
+                .min(1, t('errorMinSigners'))
+                .required(t('errorMinSigners')),
               customNonce: Yup.number(),
             }),
         }),

--- a/src/types/createDAO.ts
+++ b/src/types/createDAO.ts
@@ -64,7 +64,7 @@ export type DAOVetoGuardConfig<T = BigNumber> = {
 export interface GnosisConfiguration {
   trustedAddresses: string[];
   signatureThreshold: number;
-  numOfSigners: number;
+  numOfSigners?: number;
   customNonce: number;
 }
 


### PR DESCRIPTION
## Description

This PR updates the `GnosisMultisig` React component and the `useDAOCreateSchema` hook to simplify the process of updating and modifying the number of signers. The changes allow for easier removal and alteration of the number of signers by handling edge cases and streamlining the logic in the `handleSignersChanges` function.

## Notes

- Refactored the `handleSignersChanges` function to make it more readable and maintainable
- Added helper functions to further simplify the code and handle edge cases
- Updated the `useDAOCreateSchema` hook to accommodate the new changes

## Issue / Notion doc (if applicable)

Fixes #1111

## Testing

1. Ensure all existing tests pass and that the component still functions as expected
2. Test adding, removing, and modifying the number of signers to ensure the new logic works correctly

## Screenshots (if applicable)

![localhost_3000_create(Desktop) (2)](https://user-images.githubusercontent.com/38386583/235277840-8a523193-73a1-43d4-96a3-9ae0a8569c76.png)

![localhost_3000_create(Desktop) (1)](https://user-images.githubusercontent.com/38386583/235277844-24a1c5ef-5fea-4378-982a-5634cdb4a569.png)

![localhost_3000_create(Desktop)](https://user-images.githubusercontent.com/38386583/235277848-bdea6d63-52eb-480d-bd95-bbb5911f1814.png)
