### PR TITLE
Bugfix | Clear send asset amount input

### DIFF
--- a/src/components/ui/forms/BigNumberInput.tsx
+++ b/src/components/ui/forms/BigNumberInput.tsx
@@ -55,6 +55,7 @@ export function BigNumberInput({
   const [inputValue, setInputValue] = useState<string>();
 
   useEffect(() => {
+    console.log('🚀 ~ file: BigNumberInput.tsx:60 ~ value:', value);
     setInputValue(
       value
         ? !value.isZero()
@@ -170,6 +171,7 @@ export function BigNumberInput({
 
   // if the decimalPlaces change, need to update the value
   useEffect(() => {
+    if (!inputValue) return;
     processValue(undefined, inputValue);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [decimalPlaces]);

--- a/src/components/ui/forms/BigNumberInput.tsx
+++ b/src/components/ui/forms/BigNumberInput.tsx
@@ -51,13 +51,18 @@ export function BigNumberInput({
     }
     return input;
   };
-  const initialValue = value
-    ? !value.isZero()
-      ? removeTrailingZeros(utils.formatUnits(value, decimalPlaces))
-      : '0'
-    : '';
 
-  const [inputValue, setInputValue] = useState<string>(initialValue);
+  const [inputValue, setInputValue] = useState<string>();
+
+  useEffect(() => {
+    setInputValue(
+      value
+        ? !value.isZero()
+          ? removeTrailingZeros(utils.formatUnits(value, decimalPlaces))
+          : '0'
+        : ''
+    );
+  }, [value, decimalPlaces]);
 
   // this will insure the caret in the input component does not shift to the end of the input when the value is changed
   const resetCaretPositionForInput = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -55,6 +55,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
   });
 
   const handleCoinChange = (index: string) => {
+    setInputAmount({ value: '0', bigNumberValue: BigNumber.from(0) });
     setSelectedAsset(fungibleAssetsWithBalance[Number(index)]);
   };
 


### PR DESCRIPTION
## Description

This PR updates the `SendAssetModal` to clear asset amount input when asset is changed.

## Notes



## Issue / Notion doc (if applicable)



## Testing



## Screenshots (if applicable)

