### PR TITLE
cleans up useDecodedTransaction to cache requests

### DIFF
--- a/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
@@ -43,6 +43,7 @@ export const useAzoriusProposals = () => {
         if (args.metadata) {
           const metaDataEvent: CreateProposalMetadata = JSON.parse(args.metadata);
           const decodedTransactions = await decodeTransactions(
+            strategyContract.address,
             args.proposalId.toString(),
             args.transactions
           );
@@ -84,7 +85,11 @@ export const useAzoriusProposals = () => {
           description: metaDataEvent.description,
           documentationUrl: metaDataEvent.documentationUrl,
           transactions: transactions,
-          decodedTransactions: await decodeTransactions(proposalId.toString(), transactions),
+          decodedTransactions: await decodeTransactions(
+            strategyAddress,
+            proposalId.toString(),
+            transactions
+          ),
         };
       }
       const strategyContract = getEventRPC<LinearERC20Voting>(

--- a/src/hooks/utils/useDecodeTransaction.ts
+++ b/src/hooks/utils/useDecodeTransaction.ts
@@ -1,17 +1,18 @@
 import axios from 'axios';
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { useNetworkConfg } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { DecodedTransaction, DecodedTxParam, MetaTransaction } from '../../types';
 import { buildGnosisApiUrl, parseMultiSendTransactions } from '../../utils';
+import { DBCacheKeys, useIndexedDB } from './useLocalDB';
 
 export const useDecodeTransaction = () => {
   const { safeBaseURL } = useNetworkConfg();
-  const metaDataMapping = useRef<Map<string, DecodedTransaction[]>>(new Map());
+  const [setValue, getValue] = useIndexedDB(DBCacheKeys.DECODED_TRANSACTIONS);
 
   const decodeTransactions = useCallback(
-    async (proposalId: string, transactions: MetaTransaction[]) => {
+    async (strategyAddress: string, proposalId: string, transactions: MetaTransaction[]) => {
       const apiUrl = buildGnosisApiUrl(safeBaseURL, '/data-decoder/');
-      const cachedTransactions = metaDataMapping.current.get(proposalId.toString());
+      const cachedTransactions = await getValue(strategyAddress + '_' + proposalId.toString());
 
       if (!cachedTransactions) {
         const decodedTransactions = await Promise.all(
@@ -62,13 +63,13 @@ export const useDecodeTransaction = () => {
             }
           })
         );
-        metaDataMapping.current.set(proposalId.toString(), decodedTransactions.flat());
+        await setValue(strategyAddress + '_' + proposalId.toString(), decodedTransactions.flat());
         return decodedTransactions.flat();
       }
 
       return cachedTransactions;
     },
-    [safeBaseURL]
+    [safeBaseURL, setValue, getValue]
   );
   return decodeTransactions;
 };

--- a/src/hooks/utils/useLocalDB.ts
+++ b/src/hooks/utils/useLocalDB.ts
@@ -1,0 +1,163 @@
+import { useCallback } from 'react';
+import { useNetworkConfg } from '../../providers/NetworkConfig/NetworkConfigProvider';
+import { DecodedTransaction } from '../../types';
+
+interface IndexedObject {
+  [key: string]: any;
+}
+/**
+ * The list of cache keys used in the app.
+ *
+ * To avoid weird caching bugs, hardcoding
+ * keys should be avoided, always add the
+ * cache key here.
+ */
+export enum DBCacheKeys {
+  DECODED_TRANSACTIONS = 'DECODED_TRANSACTIONS',
+}
+/**
+ * Useful defaults for cache expiration minutes.
+ */
+export enum CacheExpiry {
+  NEVER = -1,
+  ONE_HOUR = 60,
+  ONE_DAY = ONE_HOUR * 24,
+  ONE_WEEK = ONE_DAY * 7,
+}
+
+/**
+ * Cache default values.
+ *
+ * Cache keys are not required to have a default value, but
+ * note than without one the cache will return null until
+ * a value is set.
+ */
+const CACHE_DEFAULTS: IndexedObject = {
+  [DBCacheKeys.DECODED_TRANSACTIONS.toString()]: [] as DecodedTransaction[],
+};
+
+interface IStorageValue {
+  // the value to store, 1 character to minimize cache size
+  v: any;
+  // the expiration, as a UTC timestamp
+  e: number;
+}
+
+function keyInternal(chainId: number, key: string): string {
+  return chainId + '_' + key;
+}
+
+// Helper function to create a promise-based wrapper for indexedDB
+const withIndexedDB = (callback: (db: IDBDatabase) => Promise<any>) => {
+  return new Promise((resolve, reject) => {
+    // @note database version number must be an integer, not a float
+    // @note database Version number muse be updated if the structure of the database changes
+    const openRequest = indexedDB.open('fractal', 1);
+
+    openRequest.onupgradeneeded = () => {
+      const db = openRequest.result;
+
+      // Create an object store for each CacheKey
+      for (const key in DBCacheKeys) {
+        if (!db.objectStoreNames.contains(key)) {
+          db.createObjectStore(key, { keyPath: 'key' });
+        }
+      }
+    };
+
+    openRequest.onsuccess = async () => {
+      const db = openRequest.result;
+      try {
+        const result = await callback(db);
+        resolve(result);
+      } catch (error) {
+        reject(error);
+      }
+    };
+
+    openRequest.onerror = () => {
+      reject(openRequest.error);
+    };
+  });
+};
+export const setIndexedDBValue = async (
+  objectStoreName: string,
+  key: string,
+  value: any,
+  chainId: number,
+  expirationMinutes: number = CacheExpiry.ONE_WEEK
+): Promise<void> => {
+  const val: IStorageValue = {
+    v: value,
+    e:
+      expirationMinutes === CacheExpiry.NEVER
+        ? CacheExpiry.NEVER
+        : Date.now() + expirationMinutes * 60000,
+  };
+
+  await withIndexedDB(async db => {
+    const transaction = db.transaction(objectStoreName, 'readwrite');
+    const store = transaction.objectStore(objectStoreName);
+    store.put({ key: keyInternal(chainId, key), value: val });
+  });
+};
+
+export const getIndexedDBValue = async (
+  storeKey: string,
+  key: string,
+  chainId: number
+): Promise<any> => {
+  return withIndexedDB(async db => {
+    const transaction = db.transaction(storeKey, 'readonly');
+    const store = transaction.objectStore(storeKey);
+    const request = store.get(keyInternal(chainId, key));
+
+    return new Promise((resolve, reject) => {
+      request.onsuccess = () => {
+        const result = request.result;
+
+        if (result) {
+          const parsed: IStorageValue = result.value;
+          if (parsed.e === CacheExpiry.NEVER) {
+            resolve(parsed.v);
+          } else {
+            if (parsed.e < Date.now()) {
+              setIndexedDBValue(storeKey, key, null, chainId, CacheExpiry.NEVER);
+              resolve(null);
+            } else {
+              resolve(parsed.v);
+            }
+          }
+        } else if (CACHE_DEFAULTS[key]) {
+          resolve(CACHE_DEFAULTS[key]);
+        } else {
+          resolve(null);
+        }
+      };
+
+      request.onerror = () => {
+        reject(request.error);
+      };
+    });
+  });
+};
+
+export const useIndexedDB = (objectStoreName: string) => {
+  const { chainId } = useNetworkConfg();
+
+  const set = useCallback(
+    async (key: string, value: any, expirationMinutes: number = CacheExpiry.ONE_WEEK) => {
+      await setIndexedDBValue(objectStoreName, key, value, chainId, expirationMinutes);
+    },
+    [chainId, objectStoreName]
+  );
+
+  const get = useCallback(
+    async (key: string) => {
+      return getIndexedDBValue(objectStoreName, key, chainId);
+    },
+    [chainId, objectStoreName]
+  );
+
+  return [set, get] as const;
+};

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,54 +1,6 @@
-import axios from 'axios';
 import { utils } from 'ethers';
 import { isAddress } from 'ethers/lib/utils';
 import { logError } from '../helpers/errorLogging';
-import { DecodedTransaction, DecodedTxParam, MetaTransaction } from '../types';
-import { buildGnosisApiUrl } from './api';
-import { parseMultiSendTransactions } from './azorius';
-
-export const decodeTransactions = async (
-  transactions: MetaTransaction[],
-  baseUrl: string
-): Promise<DecodedTransaction[]> => {
-  const apiUrl = buildGnosisApiUrl(baseUrl, '/data-decoder/');
-  const decodedTransactions = await Promise.all(
-    transactions.map(async tx => {
-      try {
-        const decodedData = (
-          await axios.post(apiUrl, {
-            to: tx.to,
-            data: tx.data,
-          })
-        ).data;
-
-        if (decodedData.parameters && decodedData.method === 'multiSend') {
-          const internalTransactionsMap = new Map<number, DecodedTransaction>();
-          parseMultiSendTransactions(internalTransactionsMap, decodedData.parameters);
-          return [...internalTransactionsMap.values()];
-        }
-
-        return {
-          target: tx.to,
-          value: tx.value.toString(),
-          function: decodedData.method,
-          parameterTypes: decodedData.parameters.map((param: DecodedTxParam) => param.type),
-          parameterValues: decodedData.parameters.map((param: DecodedTxParam) => param.value),
-        };
-      } catch (e) {
-        return {
-          target: tx.to,
-          value: tx.value.toString(),
-          function: 'unknown',
-          parameterTypes: [],
-          parameterValues: [],
-          decodingFailed: true,
-        };
-      }
-    })
-  );
-
-  return decodedTransactions.flat();
-};
 
 export const isSameAddress = (addr1: string, addr2: string) => {
   if (!isAddress(addr1) || !isAddress(addr2)) {


### PR DESCRIPTION
## Description
Uses The browser's indexedDB to cache some of these calls. I believe this hook can be used to cache data that will not change over time. There is a lot of opportunity here. I modeled it using `useLocalStorage` setup as a model. and this pretty much can be used in the same way. except by passing the Object's store key into the hook as a param


## Notes



## Issue / Notion doc (if applicable)



## Testing



## Screenshots (if applicable)

