### PR TITLE
Remove execution period from Azorius guard params

### DIFF
--- a/src/components/DaoCreator/formComponents/GuardDetails.tsx
+++ b/src/components/DaoCreator/formComponents/GuardDetails.tsx
@@ -119,56 +119,57 @@ function GuardDetails(props: ICreationStepProps) {
         flexDirection="column"
         gap={8}
       >
-        <ContentBoxTitle>{t('titleParentGovernance')}</ContentBoxTitle>
         {governanceFormType === GovernanceModuleType.MULTISIG && (
-          <LabelComponent
-            label={t('labelTimelockPeriod')}
-            helper={t('helperTimelockPeriod')}
-            isRequired
-          >
-            <InputGroup>
-              <BigNumberInput
-                value={values.freeze.timelockPeriod.bigNumberValue}
-                onChange={valuePair => setFieldValue('freeze.timelockPeriod', valuePair)}
-                decimalPlaces={0}
-                min="1"
-                data-testid="guardConfig-executionDetails"
-              />
-              <InputRightElement mr="4">{minutes}</InputRightElement>
-            </InputGroup>
-            <Text
-              textStyle="text-md-sans-regular"
-              color="grayscale.500"
-              mt={2}
+          <>
+            <ContentBoxTitle>{t('titleParentGovernance')}</ContentBoxTitle>
+            <LabelComponent
+              label={t('labelTimelockPeriod')}
+              helper={t('helperTimelockPeriod')}
+              isRequired
             >
-              {t('exampleTimelockPeriod')}
-            </Text>
-          </LabelComponent>
+              <InputGroup>
+                <BigNumberInput
+                  value={values.freeze.timelockPeriod.bigNumberValue}
+                  onChange={valuePair => setFieldValue('freeze.timelockPeriod', valuePair)}
+                  decimalPlaces={0}
+                  min="1"
+                  data-testid="guardConfig-executionDetails"
+                />
+                <InputRightElement mr="4">{minutes}</InputRightElement>
+              </InputGroup>
+              <Text
+                textStyle="text-md-sans-regular"
+                color="grayscale.500"
+                mt={2}
+              >
+                {t('exampleTimelockPeriod')}
+              </Text>
+            </LabelComponent>
+            <LabelComponent
+              label={t('labelExecutionPeriod')}
+              helper={t('helperExecutionPeriod')}
+              isRequired
+            >
+              <InputGroup>
+                <BigNumberInput
+                  value={values.freeze.executionPeriod.bigNumberValue}
+                  onChange={valuePair => setFieldValue('freeze.executionPeriod', valuePair)}
+                  decimalPlaces={0}
+                  min="1"
+                  data-testid="guardConfig-executionDetails"
+                />
+                <InputRightElement mr="4">{minutes}</InputRightElement>
+              </InputGroup>
+              <Text
+                textStyle="text-md-sans-regular"
+                color="grayscale.500"
+                mt={2}
+              >
+                {t('exampleExecutionPeriod')}
+              </Text>
+            </LabelComponent>
+          </>
         )}
-        <LabelComponent
-          label={t('labelExecutionPeriod')}
-          helper={t('helperExecutionPeriod')}
-          isRequired
-        >
-          <InputGroup>
-            <BigNumberInput
-              value={values.freeze.executionPeriod.bigNumberValue}
-              onChange={valuePair => setFieldValue('freeze.executionPeriod', valuePair)}
-              decimalPlaces={0}
-              min="1"
-              data-testid="guardConfig-executionDetails"
-            />
-            <InputRightElement mr="4">{minutes}</InputRightElement>
-          </InputGroup>
-          <Text
-            textStyle="text-md-sans-regular"
-            color="grayscale.500"
-            mt={2}
-          >
-            {t('exampleExecutionPeriod')}
-          </Text>
-        </LabelComponent>
-
         <ContentBoxTitle>{t('titleFreezeParams')}</ContentBoxTitle>
         <LabelComponent
           label={t('labelFreezeVotesThreshold')}


### PR DESCRIPTION
## Description

The Azorius rewrite added execution period to the Azorius protocol itself, so this parameter is no longer on the guard contract.

This PR removes the field from Azorius subDAO creation on the guard params, where it was repeated.

## Screenshots (if applicable)

Azorius subDAO:
<img width="1269" alt="Screenshot 2023-05-19 at 1 52 48 PM" src="https://github.com/decent-dao/fractal-interface/assets/384559/bdafe40c-e22d-4ed2-aaf3-158a54d74ca4">

Multisig subDAO:
<img width="1217" alt="Screenshot 2023-05-19 at 1 53 09 PM" src="https://github.com/decent-dao/fractal-interface/assets/384559/c1ac151e-e489-40c2-91ea-930f93152952">

