### PR TITLE
NFT voting DAO dashboard

### DIFF
--- a/app/daos/[daoAddress]/proposals/[proposalId]/page.tsx
+++ b/app/daos/[daoAddress]/proposals/[proposalId]/page.tsx
@@ -21,6 +21,7 @@ export default function ProposalDetailsPage({
   const {
     node: { daoAddress },
     governance: { proposals },
+    readOnly: { dao },
   } = useFractal();
 
   const [proposal, setProposal] = useState<FractalProposal | null>();
@@ -74,7 +75,7 @@ export default function ProposalDetailsPage({
         </Box>
       ) : proposal === null ? (
         <EmptyBox emptyText={t('noProposal')} />
-      ) : azoriusProposal.govTokenAddress ? (
+      ) : dao?.isAzorius ? (
         <AzoriusProposalDetails proposal={azoriusProposal} />
       ) : (
         <MultisigProposalDetails proposal={proposal} />

--- a/src/components/Proposals/ProposalActions/ProposalAction.tsx
+++ b/src/components/Proposals/ProposalActions/ProposalAction.tsx
@@ -49,11 +49,10 @@ export function ProposalAction({
 }) {
   const {
     node: { daoAddress, daoSnapshotURL },
-    readOnly: { user },
+    readOnly: { user, dao },
   } = useFractal();
   const { push } = useRouter();
   const { t } = useTranslation();
-  const isAzoriusProposal = !!(proposal as AzoriusProposal).govTokenAddress;
   const isSnapshotProposal = !!(proposal as SnapshotProposal).snapshotProposalId;
 
   const showActionButton =
@@ -76,7 +75,7 @@ export function ProposalAction({
   };
 
   const hasVoted = useMemo(() => {
-    if (isAzoriusProposal) {
+    if (dao?.isAzorius) {
       const azoriusProposal = proposal as AzoriusProposal;
       return !!azoriusProposal.votes.find(vote => vote.voter === user.address);
     } else if (isSnapshotProposal) {
@@ -86,7 +85,7 @@ export function ProposalAction({
       const safeProposal = proposal as MultisigProposal;
       return !!safeProposal.confirmations.find(confirmation => confirmation.owner === user.address);
     }
-  }, [isAzoriusProposal, isSnapshotProposal, proposal, user.address]);
+  }, [dao, isSnapshotProposal, proposal, user.address]);
 
   const labelKey = useMemo(() => {
     switch (proposal.state) {
@@ -111,10 +110,10 @@ export function ProposalAction({
       if (hasVoted) {
         return t('details');
       }
-      return t(isAzoriusProposal ? 'vote' : 'sign');
+      return t(dao?.isAzorius ? 'vote' : 'sign');
     }
     return t('details');
-  }, [isSnapshotProposal, proposal.state, t, hasVoted, isAzoriusProposal]);
+  }, [isSnapshotProposal, proposal.state, t, hasVoted, dao]);
 
   if (!showActionButton) {
     if (!expandedView) {

--- a/src/components/pages/DaoDashboard/Info/InfoGovernance.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoGovernance.tsx
@@ -151,6 +151,26 @@ export function InfoGovernance() {
           </Text>
         </Flex>
       )}
+      {governanceAzorius?.votingStrategy?.quorumThreshold && (
+        <Flex
+          alignItems="center"
+          justifyContent="space-between"
+          mb="0.25rem"
+        >
+          <Text
+            textStyle="text-base-sans-regular"
+            color="chocolate.200"
+          >
+            {t('titleQuorum')}
+          </Text>
+          <Text
+            textStyle="text-base-sans-regular"
+            color="grayscale.100"
+          >
+            {governanceAzorius.votingStrategy.quorumThreshold.formatted}
+          </Text>
+        </Flex>
+      )}
       {timelockPeriod && (
         <Flex
           alignItems="center"

--- a/src/hooks/DAO/loaders/governance/useERC721LinearStrategy.ts
+++ b/src/hooks/DAO/loaders/governance/useERC721LinearStrategy.ts
@@ -1,8 +1,8 @@
-import { Azorius, LinearERC20Voting } from '@fractal-framework/fractal-contracts';
+import { Azorius, LinearERC721Voting } from '@fractal-framework/fractal-contracts';
 import { TypedListener } from '@fractal-framework/fractal-contracts/dist/typechain-types/common';
 import { TimelockPeriodUpdatedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/MultisigFreezeGuard';
-import { QuorumNumeratorUpdatedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/BaseQuorumPercent';
 import { VotingPeriodUpdatedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/LinearERC20Voting';
+import { QuorumThresholdUpdatedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/LinearERC721Voting';
 import { BigNumber } from 'ethers';
 import { useCallback, useEffect } from 'react';
 import { useProvider } from 'wagmi';
@@ -13,9 +13,9 @@ import { GovernanceSelectionType, VotingStrategyType } from '../../../../types';
 import { blocksToSeconds } from '../../../../utils/contract';
 import { useTimeHelpers } from '../../../utils/useTimeHelpers';
 
-export const useERC20LinearStrategy = () => {
+export const useERC721LinearStrategy = () => {
   const {
-    governanceContracts: { ozLinearVotingContract, azoriusContract },
+    governanceContracts: { erc721LinearVotingContract, azoriusContract },
     action,
   } = useFractal();
   const provider = useProvider();
@@ -25,43 +25,43 @@ export const useERC20LinearStrategy = () => {
   const { getTimeDuration } = useTimeHelpers();
 
   const loadERC20Strategy = useCallback(async () => {
-    if (!ozLinearVotingContract || !azoriusContract) {
+    if (!erc721LinearVotingContract || !azoriusContract) {
       return {};
     }
-    const [votingPeriodBlocks, quorumPercentage, timeLockPeriod] = await Promise.all([
-      ozLinearVotingContract.asSigner.votingPeriod(),
-      ozLinearVotingContract.asSigner.quorumNumerator(),
+    const [votingPeriodBlocks, quorumThreshold, timeLockPeriod] = await Promise.all([
+      erc721LinearVotingContract.asSigner.votingPeriod(),
+      erc721LinearVotingContract.asSigner.quorumThreshold(),
       azoriusContract.asSigner.timelockPeriod(),
     ]);
 
     const votingPeriodValue = await blocksToSeconds(votingPeriodBlocks, provider);
     const timeLockPeriodValue = await blocksToSeconds(timeLockPeriod, provider);
     const votingData = {
-      governanceType: GovernanceSelectionType.AZORIUS_ERC20,
+      governanceType: GovernanceSelectionType.AZORIUS_ERC721,
       votingStrategy: {
         votingPeriod: {
           value: BigNumber.from(votingPeriodValue),
           formatted: getTimeDuration(votingPeriodValue),
         },
-        quorumPercentage: {
-          value: quorumPercentage,
-          formatted: quorumPercentage.toString() + '%',
+        quorumThreshold: {
+          value: quorumThreshold,
+          formatted: quorumThreshold.toString(),
         },
         timeLockPeriod: {
           value: BigNumber.from(timeLockPeriodValue),
           formatted: getTimeDuration(timeLockPeriodValue),
         },
-        strategyType: VotingStrategyType.LINEAR_ERC20,
+        strategyType: VotingStrategyType.LINEAR_ERC721,
       },
     };
     action.dispatch({ type: FractalGovernanceAction.SET_STRATEGY, payload: votingData });
-  }, [ozLinearVotingContract, azoriusContract, getTimeDuration, action, provider]);
+  }, [erc721LinearVotingContract, azoriusContract, getTimeDuration, action, provider]);
 
   useEffect(() => {
-    if (!ozLinearVotingContract) {
+    if (!erc721LinearVotingContract) {
       return;
     }
-    const rpc = getEventRPC<LinearERC20Voting>(ozLinearVotingContract, chainId);
+    const rpc = getEventRPC<LinearERC721Voting>(erc721LinearVotingContract, chainId);
     const votingPeriodfilter = rpc.filters.VotingPeriodUpdated();
     const listener: TypedListener<VotingPeriodUpdatedEvent> = votingPeriod => {
       action.dispatch({
@@ -73,27 +73,27 @@ export const useERC20LinearStrategy = () => {
     return () => {
       rpc.off(votingPeriodfilter, listener);
     };
-  }, [ozLinearVotingContract, chainId, action]);
+  }, [erc721LinearVotingContract, chainId, action]);
 
   useEffect(() => {
-    if (!ozLinearVotingContract) {
+    if (!erc721LinearVotingContract) {
       return;
     }
-    const rpc = getEventRPC<LinearERC20Voting>(ozLinearVotingContract, chainId);
-    const quorumNumeratorUpdatedFilter = rpc.filters.QuorumNumeratorUpdated();
-    const quorumNumeratorUpdatedListener: TypedListener<
-      QuorumNumeratorUpdatedEvent
-    > = quorumPercentage => {
+    const rpc = getEventRPC<LinearERC721Voting>(erc721LinearVotingContract, chainId);
+    const quorumThresholdUpdatedFilter = rpc.filters.QuorumThresholdUpdated();
+    const quorumThresholdUpdatedListener: TypedListener<
+      QuorumThresholdUpdatedEvent
+    > = quorumThreshold => {
       action.dispatch({
-        type: FractalGovernanceAction.UPDATE_VOTING_QUORUM,
-        payload: quorumPercentage,
+        type: FractalGovernanceAction.UPDATE_VOTING_QUORUM_THRESHOLD,
+        payload: quorumThreshold,
       });
     };
-    rpc.on(quorumNumeratorUpdatedFilter, quorumNumeratorUpdatedListener);
+    rpc.on(quorumThresholdUpdatedFilter, quorumThresholdUpdatedListener);
     return () => {
-      rpc.off(quorumNumeratorUpdatedFilter, quorumNumeratorUpdatedListener);
+      rpc.off(quorumThresholdUpdatedFilter, quorumThresholdUpdatedListener);
     };
-  }, [ozLinearVotingContract, chainId, action]);
+  }, [erc721LinearVotingContract, chainId, action]);
 
   useEffect(() => {
     if (!azoriusContract) {

--- a/src/hooks/DAO/loaders/useFractalGovernance.ts
+++ b/src/hooks/DAO/loaders/useFractalGovernance.ts
@@ -7,6 +7,7 @@ import { FractalGovernanceAction } from '../../../providers/App/governance/actio
 import useIPFSClient from '../../../providers/App/hooks/useIPFSClient';
 import { useERC20LinearStrategy } from './governance/useERC20LinearStrategy';
 import { useERC20LinearToken } from './governance/useERC20LinearToken';
+import { useERC721LinearStrategy } from './governance/useERC721LinearStrategy';
 import { useDAOProposals } from './useProposals';
 
 export const useFractalGovernance = () => {
@@ -22,6 +23,7 @@ export const useFractalGovernance = () => {
 
   const loadDAOProposals = useDAOProposals();
   const loadERC20Strategy = useERC20LinearStrategy();
+  const loadERC721Strategy = useERC721LinearStrategy();
   const { loadERC20Token, loadUnderlyingERC20Token } = useERC20LinearToken({});
   const ipfsClient = useIPFSClient();
 
@@ -64,7 +66,8 @@ export const useFractalGovernance = () => {
   });
 
   useEffect(() => {
-    const { isLoaded, azoriusContract } = governanceContracts;
+    const { isLoaded, azoriusContract, erc721LinearVotingContract, ozLinearVotingContract } =
+      governanceContracts;
 
     const newLoadKey =
       daoAddress +
@@ -78,9 +81,13 @@ export const useFractalGovernance = () => {
       loadDAOProposals();
 
       if (azoriusContract) {
-        loadERC20Strategy();
-        loadERC20Token();
-        loadUnderlyingERC20Token();
+        if (ozLinearVotingContract) {
+          loadERC20Strategy();
+          loadERC20Token();
+          loadUnderlyingERC20Token();
+        } else if (erc721LinearVotingContract) {
+          loadERC721Strategy();
+        }
       }
     } else if (!isLoaded) {
       loadKey.current = undefined;
@@ -94,5 +101,6 @@ export const useFractalGovernance = () => {
     loadERC20Token,
     nodeHierarchy.parentAddress,
     guardContracts.freezeGuardContract,
+    loadERC721Strategy,
   ]);
 };

--- a/src/hooks/DAO/loaders/useGovernanceContracts.ts
+++ b/src/hooks/DAO/loaders/useGovernanceContracts.ts
@@ -4,6 +4,7 @@ import {
   LinearERC20Voting,
   VotesERC20,
   VotesERC20Wrapper,
+  LinearERC721Voting,
 } from '@fractal-framework/fractal-contracts';
 import { useCallback, useEffect, useRef } from 'react';
 import { useProvider } from 'wagmi';
@@ -27,6 +28,7 @@ export const useGovernanceContracts = () => {
     baseContracts: {
       zodiacModuleProxyFactoryContract,
       linearVotingMasterCopyContract,
+      linearVotingERC721MasterCopyContract,
       votesTokenMasterCopyContract,
       fractalAzoriusMasterCopyContract,
       votesERC20WrapperMasterCopyContract,
@@ -67,6 +69,7 @@ export const useGovernanceContracts = () => {
         let govTokenAddress: string | undefined = cachedContractAddresses?.govTokenContractAddress;
 
         let ozLinearVotingContract: ContractConnection<LinearERC20Voting> | undefined;
+        let erc721LinearVotingContract: ContractConnection<LinearERC721Voting> | undefined;
         let tokenContract: ContractConnection<VotesERC20 | VotesERC20Wrapper> | undefined;
         let underlyingTokenAddress: string | undefined;
 
@@ -90,6 +93,16 @@ export const useGovernanceContracts = () => {
           ozLinearVotingContract = {
             asSigner: linearVotingMasterCopyContract.asSigner.attach(votingContractAddress!),
             asProvider: linearVotingMasterCopyContract.asProvider.attach(votingContractAddress!),
+          };
+        } else if (
+          votingContractMasterCopyAddress ===
+          linearVotingERC721MasterCopyContract.asProvider.address
+        ) {
+          erc721LinearVotingContract = {
+            asSigner: linearVotingERC721MasterCopyContract.asSigner.attach(votingContractAddress!),
+            asProvider: linearVotingERC721MasterCopyContract.asProvider.attach(
+              votingContractAddress!
+            ),
           };
         }
         if (ozLinearVotingContract) {
@@ -129,8 +142,25 @@ export const useGovernanceContracts = () => {
             type: GovernanceContractAction.SET_GOVERNANCE_CONTRACT,
             payload: {
               ozLinearVotingContract,
+              erc721LinearVotingContract: null,
               azoriusContract,
               tokenContract,
+              underlyingTokenAddress,
+            },
+          });
+        } else if (!!erc721LinearVotingContract) {
+          setValue(AZORIUS_MODULE_CACHE_KEY + azoriusModule.address, {
+            votingContractAddress,
+            votingContractMasterCopyAddress,
+          });
+          currentValidAddress.current = _node.daoAddress;
+          action.dispatch({
+            type: GovernanceContractAction.SET_GOVERNANCE_CONTRACT,
+            payload: {
+              ozLinearVotingContract: null,
+              erc721LinearVotingContract,
+              azoriusContract,
+              tokenContract: null,
               underlyingTokenAddress,
             },
           });
@@ -140,6 +170,7 @@ export const useGovernanceContracts = () => {
             type: GovernanceContractAction.SET_GOVERNANCE_CONTRACT,
             payload: {
               ozLinearVotingContract: null,
+              erc721LinearVotingContract: null,
               azoriusContract: null,
               tokenContract: null,
             },
@@ -152,6 +183,7 @@ export const useGovernanceContracts = () => {
           payload: {
             ozLinearVotingContract: null,
             azoriusContract: null,
+            erc721LinearVotingContract: null,
             tokenContract: null,
           },
         });
@@ -167,6 +199,7 @@ export const useGovernanceContracts = () => {
       zodiacModuleProxyFactoryContract,
       fractalAzoriusMasterCopyContract,
       votesERC20WrapperMasterCopyContract,
+      linearVotingERC721MasterCopyContract,
     ]
   );
 

--- a/src/hooks/DAO/loaders/useProposals.ts
+++ b/src/hooks/DAO/loaders/useProposals.ts
@@ -18,20 +18,29 @@ export const useDAOProposals = () => {
   const loadSafeMultisigProposals = useSafeMultisigProposals();
   const { setMethodOnInterval } = useUpdateTimer(daoAddress);
   const loadDAOProposals = useCallback(async () => {
-    const { azoriusContract } = governanceContracts;
+    const { azoriusContract, ozLinearVotingContract, erc721LinearVotingContract } =
+      governanceContracts;
 
     if (!!azoriusContract) {
       // load Azorius proposals and strategies
-      try {
-        action.dispatch({
-          type: FractalGovernanceAction.SET_PROPOSALS,
-          payload: {
-            type: GovernanceSelectionType.AZORIUS_ERC20,
-            proposals: await loadAzoriusProposals(),
-          },
-        });
-      } catch (e) {
-        logError(e);
+      let type = ozLinearVotingContract
+        ? GovernanceSelectionType.AZORIUS_ERC20
+        : erc721LinearVotingContract
+        ? GovernanceSelectionType.AZORIUS_ERC721
+        : undefined;
+
+      if (type) {
+        try {
+          action.dispatch({
+            type: FractalGovernanceAction.SET_PROPOSALS,
+            payload: {
+              type,
+              proposals: await loadAzoriusProposals(),
+            },
+          });
+        } catch (e) {
+          logError(e);
+        }
       }
     } else {
       // load mulisig proposals

--- a/src/providers/App/governance/action.ts
+++ b/src/providers/App/governance/action.ts
@@ -22,6 +22,7 @@ export enum FractalGovernanceAction {
   UPDATE_PROPOSAL_STATE = 'UPDATE_PROPOSAL_STATE',
   UPDATE_VOTING_PERIOD = 'UPDATE_VOTING_PERIOD',
   UPDATE_VOTING_QUORUM = 'UPDATE_VOTING_QUORUM',
+  UPDATE_VOTING_QUORUM_THRESHOLD = 'UPDATE_VOTING_QUORUM_THRESHOLD',
   UPDATE_TIMELOCK_PERIOD = 'UPDATE_TIMELOCK_PERIOD',
   SET_TOKEN_DATA = 'SET_TOKEN_DATA',
   SET_TOKEN_ACCOUNT_DATA = 'SET_TOKEN_ACCOUNT_DATA',
@@ -30,8 +31,13 @@ export enum FractalGovernanceAction {
   SET_UNDERLYING_TOKEN_DATA = 'SET_UNDERLYING_TOKEN_DATA',
 }
 
+type SetStrategyPayload = {
+  governanceType: GovernanceSelectionType;
+  votingStrategy: VotingStrategy;
+};
+
 export type FractalGovernanceActions =
-  | { type: FractalGovernanceAction.SET_STRATEGY; payload: VotingStrategy }
+  | { type: FractalGovernanceAction.SET_STRATEGY; payload: SetStrategyPayload }
   | {
       type: FractalGovernanceAction.SET_PROPOSALS;
       payload: { type: GovernanceSelectionType; proposals: FractalProposal[] };
@@ -64,6 +70,10 @@ export type FractalGovernanceActions =
     }
   | {
       type: FractalGovernanceAction.UPDATE_VOTING_QUORUM;
+      payload: BigNumber;
+    }
+  | {
+      type: FractalGovernanceAction.UPDATE_VOTING_QUORUM_THRESHOLD;
       payload: BigNumber;
     }
   | {

--- a/src/providers/App/governance/reducer.ts
+++ b/src/providers/App/governance/reducer.ts
@@ -1,5 +1,5 @@
 import { FractalGovernance, AzoriusProposal, VOTE_CHOICES, SnapshotProposal } from '../../../types';
-import { AzoriusGovernance, GovernanceSelectionType } from './../../../types/fractal';
+import { AzoriusGovernance } from './../../../types/fractal';
 import { FractalGovernanceAction, FractalGovernanceActions } from './action';
 
 export const initialGovernanceState: FractalGovernance = {
@@ -39,8 +39,8 @@ export const governanceReducer = (state: FractalGovernance, action: FractalGover
     case FractalGovernanceAction.SET_STRATEGY: {
       return {
         ...state,
-        type: GovernanceSelectionType.AZORIUS_ERC20,
-        votingStrategy: action.payload,
+        type: action.payload.governanceType,
+        votingStrategy: { ...action.payload.votingStrategy },
       };
     }
     case FractalGovernanceAction.SET_SNAPSHOT_PROPOSALS:
@@ -85,6 +85,10 @@ export const governanceReducer = (state: FractalGovernance, action: FractalGover
     case FractalGovernanceAction.UPDATE_VOTING_PERIOD: {
       const { votingStrategy } = state as AzoriusGovernance;
       return { ...state, votingStrategy: { ...votingStrategy, votingPeriod: action.payload } };
+    }
+    case FractalGovernanceAction.UPDATE_VOTING_QUORUM_THRESHOLD: {
+      const { votingStrategy } = state as AzoriusGovernance;
+      return { ...state, votingStrategy: { ...votingStrategy, quorumThreshold: action.payload } };
     }
     case FractalGovernanceAction.UPDATE_VOTING_QUORUM: {
       const { votingStrategy } = state as AzoriusGovernance;

--- a/src/providers/App/governanceContracts/reducer.ts
+++ b/src/providers/App/governanceContracts/reducer.ts
@@ -3,6 +3,7 @@ import { GovernanceContractAction, GovernanceContractActions } from './action';
 
 export const initialGovernanceContractsState: FractalGovernanceContracts = {
   ozLinearVotingContract: null,
+  erc721LinearVotingContract: null,
   azoriusContract: null,
   tokenContract: null,
   isLoaded: false,

--- a/src/types/daoProposal.ts
+++ b/src/types/daoProposal.ts
@@ -30,7 +30,6 @@ export type ProposalMetaData = {
 
 export interface AzoriusProposal extends GovernanceActivity {
   proposer: string;
-  govTokenAddress: string | null;
   votesSummary: ProposalVotesSummary;
   votes: ProposalVote[];
   /** The deadline timestamp for the proposal, in milliseconds. */

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -232,6 +232,7 @@ export interface FractalClients {
 
 export interface FractalGovernanceContracts {
   ozLinearVotingContract: ContractConnection<LinearERC20Voting> | null;
+  erc721LinearVotingContract: ContractConnection<LinearERC721Voting> | null;
   azoriusContract: ContractConnection<Azorius> | null;
   tokenContract: ContractConnection<VotesERC20 | VotesERC20Wrapper> | null;
   underlyingTokenAddress?: string;
@@ -306,6 +307,7 @@ export interface VotingStrategyAzorius extends VotingStrategy {
 export interface VotingStrategy<Type = BNFormattedPair> {
   votingPeriod?: Type;
   quorumPercentage?: Type;
+  quorumThreshold?: Type;
   timeLockPeriod?: Type;
 }
 


### PR DESCRIPTION
## Description

This PR implements proper governance retrieving for ERC-721 DAO.
Aka it sets `erc721LinearVotingContract` globally in the `FractalStore` and adjusts data flow to fetch it's details and properly identify that DAO is ERC-721 DAO and not ERC-20
It also properly loads the data for ERC-721 Voting strategy proposals and removes some boundaries to ERC-20 to make Azorius proposals more generic

## Notes
N/A

## Issue / Notion doc (if applicable)
N/A

## Testing
1. Create brand new NFT Voting DAO
2. Visit it's Dashboard
3. Verify that all the details (voting period, quorum threshold, DAO Type, Timelock period) is displayed properly under Governance Info


## Screenshots (if applicable)

<img width="1678" alt="Знімок екрана 2023-07-13 о 02 56 37" src="https://github.com/decent-dao/fractal-interface/assets/25801162/82ecba22-eb6b-49f5-86fe-607f62da856c">
