### PR TITLE
fix divide by zero in treasury

### DIFF
--- a/src/components/pages/DAOTreasury/components/Assets.tsx
+++ b/src/components/pages/DAOTreasury/components/Assets.tsx
@@ -136,7 +136,7 @@ function CoinRow({
           textStyle="text-base-sans-regular"
           color="grayscale.100"
         >
-          {formatPercentage(asset.fiatValue, totalFiat)}
+          {totalFiat > 0 && formatPercentage(asset.fiatValue, totalFiat)}
         </Text>
       </Box>
     </HStack>


### PR DESCRIPTION
## Description

calculating a percentage with a zero denominator caused a divide by zero exception, this fixes that

checked other usages of `formatPercentage` and saw no other potential issues, also decided the fix should be outside `formatPercentage`, since not throwing the exception would mask future bugs
