### PR TITLE
Removed `getPending` from `LockRelease` contract

### DIFF
--- a/src/hooks/DAO/loaders/governance/useLockRelease.ts
+++ b/src/hooks/DAO/loaders/governance/useLockRelease.ts
@@ -30,11 +30,13 @@ export const useLockRelease = ({ onMount = true }: { onMount?: boolean }) => {
       action.dispatch({ type: DecentGovernanceAction.RESET_LOCKED_TOKEN_ACCOUNT_DATA });
       return;
     }
-    const [tokenBalance, tokenDelegatee, tokenVotingWeight] = await Promise.all([
-      lockReleaseContract.asSigner.getPending(account),
-      lockReleaseContract.asSigner.delegates(account),
-      lockReleaseContract.asSigner.getVotes(account),
-    ]);
+    const [tokenAmountTotal, tokenAmountReleased, tokenDelegatee, tokenVotingWeight] =
+      await Promise.all([
+        lockReleaseContract.asSigner.getTotal(account),
+        lockReleaseContract.asSigner.getReleased(account),
+        lockReleaseContract.asSigner.delegates(account),
+        lockReleaseContract.asSigner.getVotes(account),
+      ]);
 
     let delegateChangeEvents: DelegateChangedEvent[];
     try {
@@ -46,7 +48,7 @@ export const useLockRelease = ({ onMount = true }: { onMount?: boolean }) => {
     }
 
     const tokenAccountData = {
-      balance: tokenBalance,
+      balance: tokenAmountTotal.sub(tokenAmountReleased),
       delegatee: tokenDelegatee,
       votingWeight: tokenVotingWeight,
       isDelegatesSet: delegateChangeEvents.length > 0,


### PR DESCRIPTION
## Description

The `LockRelease` contract has been cleaned up a bit, and two public functions have been removed. One of those functions was being used in this `fractal-interface` codebase, which necessitates and update here with some functionally equivalent code.

## Notes

The `getPending` function is the one which was removed from `LockRelease`, and being used here. The old implementation of `getPending` in the contract simply subtracted one public number from another public number. So, that's what I've done in this PR: fetch both of those numbers then do the subtraction client side.

The other removed function, `getBeneficiaries`, I don't see being used in this `fractal-interface` codebase.

## Issue / Notion doc (if applicable)

Here's the commit that introduced this change in the `DCNT` repo: https://github.com/decent-dao/dcnt/commit/a2af5e0507c293219d94375ef3f058b1f8fe1d28

## Testing

n/a

## Screenshots (if applicable)

n/a