### PR TITLE
Voting Strategies Upgrade + Master Copy Caching

### DIFF
--- a/app/daos/[daoAddress]/proposals/new/page.tsx
+++ b/app/daos/[daoAddress]/proposals/new/page.tsx
@@ -73,7 +73,6 @@ export default function ProposalCreatePage() {
             successToastMessage: t('proposalCreateSuccessToastMessage'),
             failedToastMessage: t('proposalCreateFailureToastMessage'),
             successCallback,
-            safeAddress: daoAddress,
           });
         }}
         validateOnMount

--- a/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
+++ b/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
@@ -17,6 +17,7 @@ import {
 import useSubmitProposal from '../../../../hooks/DAO/proposal/useSubmitProposal';
 import useUserERC721VotingTokens from '../../../../hooks/DAO/proposal/useUserERC721VotingTokens';
 import useClawBack from '../../../../hooks/DAO/useClawBack';
+import { CacheKeys } from '../../../../hooks/utils/cache/cacheDefaults';
 import { useLocalStorage } from '../../../../hooks/utils/cache/useLocalStorage';
 import useBlockTimestamp from '../../../../hooks/utils/useBlockTimestamp';
 import { useFractal } from '../../../../providers/App/AppProvider';
@@ -116,7 +117,9 @@ export function ManageDAOMenu({
                 0
               )
             )[1];
-            const cachedMasterCopyAddress = getValue('master_copy_of_' + votingContractAddress);
+            const cachedMasterCopyAddress = getValue(
+              CacheKeys.MASTER_COPY_PREFIX + votingContractAddress
+            );
             let votingContractMasterCopyAddress = cachedMasterCopyAddress;
             if (!votingContractMasterCopyAddress) {
               const rpc = getEventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract);
@@ -126,7 +129,10 @@ export function ManageDAOMenu({
                 .then(proxiesCreated => {
                   return proxiesCreated[0].args.masterCopy;
                 });
-              setValue('master_copy_of_' + votingContractAddress, votingContractMasterCopyAddress);
+              setValue(
+                CacheKeys.MASTER_COPY_PREFIX + votingContractAddress,
+                votingContractMasterCopyAddress
+              );
             }
 
             if (

--- a/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
+++ b/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
@@ -113,21 +113,20 @@ export function ManageDAOMenu({
             const votingContractAddress = (
               await azoriusContract.asProvider.getStrategies(
                 '0x0000000000000000000000000000000000000001',
-                1
+                0
               )
-            )[0][0];
-            const cachedMasterCopyAddress = getValue('master_copy_of' + votingContractAddress);
+            )[1];
+            const cachedMasterCopyAddress = getValue('master_copy_of_' + votingContractAddress);
             let votingContractMasterCopyAddress = cachedMasterCopyAddress;
             if (!votingContractMasterCopyAddress) {
               const rpc = getEventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract);
               const filter = rpc.filters.ModuleProxyCreation(votingContractAddress, null);
-
               votingContractMasterCopyAddress = await rpc
                 .queryFilter(filter)
                 .then(proxiesCreated => {
                   return proxiesCreated[0].args.masterCopy;
                 });
-              setValue('master_copy_of' + votingContractAddress, votingContractMasterCopyAddress);
+              setValue('master_copy_of_' + votingContractAddress, votingContractMasterCopyAddress);
             }
 
             if (

--- a/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
+++ b/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
@@ -2,7 +2,6 @@ import { VEllipsis } from '@decent-org/fractal-ui';
 import {
   ERC20FreezeVoting,
   ERC721FreezeVoting,
-  Azorius,
   ModuleProxyFactory,
   MultisigFreezeVoting,
 } from '@fractal-framework/fractal-contracts';
@@ -107,11 +106,14 @@ export function ManageDAOMenu({
                 azoriusModule.moduleAddress
               ),
             };
-            const votingContractAddress = await getEventRPC<Azorius>(azoriusContract)
-              .queryFilter((azoriusModule.moduleContract as Azorius).filters.EnabledStrategy())
-              .then(strategiesEnabled => {
-                return strategiesEnabled[0].args.strategy;
-              });
+
+            // Get the voting contract address
+            const votingContractAddress = (
+              await azoriusContract.asProvider.getStrategies(
+                '0x0000000000000000000000000000000000000001',
+                1
+              )
+            )[0][0];
             const rpc = getEventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract);
             const filter = rpc.filters.ModuleProxyCreation(votingContractAddress, null);
             const votingContractMasterCopyAddress = await rpc

--- a/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
+++ b/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
@@ -109,7 +109,7 @@ export function ManageDAOMenu({
               ),
             };
 
-            // Get the voting contract address
+            // @dev assumes the first strategy is the voting contract
             const votingContractAddress = (
               await azoriusContract.asProvider.getStrategies(
                 '0x0000000000000000000000000000000000000001',

--- a/src/hooks/DAO/loaders/useFractalModules.ts
+++ b/src/hooks/DAO/loaders/useFractalModules.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { getEventRPC } from '../../../helpers';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { FractalModuleData, FractalModuleType } from '../../../types';
+import { CacheKeys } from '../../utils/cache/cacheDefaults';
 import { useLocalStorage } from './../../utils/cache/useLocalStorage';
 
 export const useFractalModules = () => {
@@ -20,12 +21,12 @@ export const useFractalModules = () => {
     async (_moduleAddresses: string[]) => {
       const rpc = getEventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract);
       const getMasterCopyAddress = async (proxyAddress: string): Promise<string> => {
-        const cachedValue = getValue('master_copy_of_' + proxyAddress);
+        const cachedValue = getValue(CacheKeys.MASTER_COPY_PREFIX + proxyAddress);
         if (cachedValue) return cachedValue;
         const filter = rpc.filters.ModuleProxyCreation(proxyAddress, null);
         return rpc.queryFilter(filter).then(proxiesCreated => {
           if (proxiesCreated.length === 0) return constants.AddressZero;
-          setValue('master_copy_of_' + proxyAddress, proxiesCreated[0].args.masterCopy);
+          setValue(CacheKeys.MASTER_COPY_PREFIX + proxyAddress, proxiesCreated[0].args.masterCopy);
           return proxiesCreated[0].args.masterCopy;
         });
       };

--- a/src/hooks/DAO/loaders/useFractalModules.ts
+++ b/src/hooks/DAO/loaders/useFractalModules.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { getEventRPC } from '../../../helpers';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { FractalModuleData, FractalModuleType } from '../../../types';
+import { useLocalStorage } from './../../utils/cache/useLocalStorage';
 
 export const useFractalModules = () => {
   const {
@@ -13,14 +14,18 @@ export const useFractalModules = () => {
       fractalModuleMasterCopyContract,
     },
   } = useFractal();
+  const { setValue, getValue } = useLocalStorage();
 
   const lookupModules = useCallback(
     async (_moduleAddresses: string[]) => {
       const rpc = getEventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract);
       const getMasterCopyAddress = async (proxyAddress: string): Promise<string> => {
+        const cachedValue = getValue('master_copy_of' + proxyAddress);
+        if (cachedValue) return cachedValue;
         const filter = rpc.filters.ModuleProxyCreation(proxyAddress, null);
         return rpc.queryFilter(filter).then(proxiesCreated => {
           if (proxiesCreated.length === 0) return constants.AddressZero;
+          setValue('master_copy_of' + proxyAddress, proxiesCreated[0].args.masterCopy);
           return proxiesCreated[0].args.masterCopy;
         });
       };
@@ -63,6 +68,8 @@ export const useFractalModules = () => {
       zodiacModuleProxyFactoryContract,
       fractalAzoriusMasterCopyContract,
       fractalModuleMasterCopyContract,
+      getValue,
+      setValue,
     ]
   );
   return lookupModules;

--- a/src/hooks/DAO/loaders/useFractalModules.ts
+++ b/src/hooks/DAO/loaders/useFractalModules.ts
@@ -20,12 +20,12 @@ export const useFractalModules = () => {
     async (_moduleAddresses: string[]) => {
       const rpc = getEventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract);
       const getMasterCopyAddress = async (proxyAddress: string): Promise<string> => {
-        const cachedValue = getValue('master_copy_of' + proxyAddress);
+        const cachedValue = getValue('master_copy_of_' + proxyAddress);
         if (cachedValue) return cachedValue;
         const filter = rpc.filters.ModuleProxyCreation(proxyAddress, null);
         return rpc.queryFilter(filter).then(proxiesCreated => {
           if (proxiesCreated.length === 0) return constants.AddressZero;
-          setValue('master_copy_of' + proxyAddress, proxiesCreated[0].args.masterCopy);
+          setValue('master_copy_of_' + proxyAddress, proxiesCreated[0].args.masterCopy);
           return proxiesCreated[0].args.masterCopy;
         });
       };

--- a/src/hooks/DAO/loaders/useGovernanceContracts.ts
+++ b/src/hooks/DAO/loaders/useGovernanceContracts.ts
@@ -78,11 +78,12 @@ export const useGovernanceContracts = () => {
         let lockReleaseContract: ContractConnection<LockRelease> | null = null;
 
         if (!votingContractAddress) {
-          votingContractAddress = await getEventRPC<Azorius>(azoriusContract)
-            .queryFilter(azoriusModuleContract.filters.EnabledStrategy())
-            .then(strategiesEnabled => {
-              return strategiesEnabled[0].args.strategy;
-            });
+          votingContractAddress = (
+            await azoriusContract.asProvider.getStrategies(
+              '0x0000000000000000000000000000000000000001',
+              1
+            )
+          )[0][0];
         }
 
         if (!votingContractMasterCopyAddress) {

--- a/src/hooks/DAO/loaders/useGovernanceContracts.ts
+++ b/src/hooks/DAO/loaders/useGovernanceContracts.ts
@@ -81,9 +81,9 @@ export const useGovernanceContracts = () => {
           votingContractAddress = (
             await azoriusContract.asProvider.getStrategies(
               '0x0000000000000000000000000000000000000001',
-              1
+              0
             )
-          )[0][0];
+          )[1];
         }
 
         if (!votingContractMasterCopyAddress) {

--- a/src/hooks/DAO/loaders/useGovernanceContracts.ts
+++ b/src/hooks/DAO/loaders/useGovernanceContracts.ts
@@ -78,6 +78,7 @@ export const useGovernanceContracts = () => {
         let lockReleaseContract: ContractConnection<LockRelease> | null = null;
 
         if (!votingContractAddress) {
+          // @dev assumes the first strategy is the voting contract
           votingContractAddress = (
             await azoriusContract.asProvider.getStrategies(
               '0x0000000000000000000000000000000000000001',

--- a/src/hooks/DAO/loaders/useGovernanceContracts.ts
+++ b/src/hooks/DAO/loaders/useGovernanceContracts.ts
@@ -14,6 +14,7 @@ import { useFractal } from '../../../providers/App/AppProvider';
 import { GovernanceContractAction } from '../../../providers/App/governanceContracts/action';
 import { ContractConnection } from '../../../types';
 import { getAzoriusModuleFromModules } from '../../../utils';
+import { CacheKeys } from '../../utils/cache/cacheDefaults';
 import { useLocalStorage } from '../../utils/cache/useLocalStorage';
 import { useEthersProvider } from '../../utils/useEthersProvider';
 import useSignerOrProvider from '../../utils/useSignerOrProvider';
@@ -59,17 +60,9 @@ export const useGovernanceContracts = () => {
           ),
           asSigner: fractalAzoriusMasterCopyContract.asSigner.attach(azoriusModuleContract.address),
         };
-        const cachedContractAddresses = getValue(
-          'azorius_module_gov_' + azoriusModuleContract.address
-        );
 
-        // if existing cached addresses are found, use them
-        let votingContractAddress: string | undefined =
-          cachedContractAddresses?.votingContractAddress;
-
-        let votingContractMasterCopyAddress: string | undefined =
-          cachedContractAddresses?.votingContractMasterCopyAddress;
-        let govTokenAddress: string | undefined = cachedContractAddresses?.govTokenContractAddress;
+        let votingContractMasterCopyAddress: string | undefined;
+        let govTokenAddress: string | undefined;
 
         let ozLinearVotingContract: ContractConnection<LinearERC20Voting> | undefined;
         let erc721LinearVotingContract: ContractConnection<LinearERC721Voting> | undefined;
@@ -77,22 +70,28 @@ export const useGovernanceContracts = () => {
         let underlyingTokenAddress: string | undefined;
         let lockReleaseContract: ContractConnection<LockRelease> | null = null;
 
-        if (!votingContractAddress) {
-          // @dev assumes the first strategy is the voting contract
-          votingContractAddress = (
-            await azoriusContract.asProvider.getStrategies(
-              '0x0000000000000000000000000000000000000001',
-              0
-            )
-          )[1];
-        }
+        // @dev assumes the first strategy is the voting contract
+        const votingContractAddress = (
+          await azoriusContract.asProvider.getStrategies(
+            '0x0000000000000000000000000000000000000001',
+            0
+          )
+        )[1];
 
         if (!votingContractMasterCopyAddress) {
-          const rpc = getEventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract);
-          const filter = rpc.filters.ModuleProxyCreation(votingContractAddress, null);
-          votingContractMasterCopyAddress = await rpc.queryFilter(filter).then(proxiesCreated => {
-            return proxiesCreated[0].args.masterCopy;
-          });
+          const cachedValue = getValue(CacheKeys.MASTER_COPY_PREFIX + votingContractAddress);
+          votingContractMasterCopyAddress = cachedValue;
+          if (!cachedValue) {
+            const rpc = getEventRPC<ModuleProxyFactory>(zodiacModuleProxyFactoryContract);
+            const filter = rpc.filters.ModuleProxyCreation(votingContractAddress, null);
+            votingContractMasterCopyAddress = await rpc.queryFilter(filter).then(proxiesCreated => {
+              setValue(
+                CacheKeys.MASTER_COPY_PREFIX + votingContractAddress,
+                proxiesCreated[0].args.masterCopy
+              );
+              return proxiesCreated[0].args.masterCopy;
+            });
+          }
         }
 
         if (votingContractMasterCopyAddress === linearVotingMasterCopyContract.asProvider.address) {

--- a/src/hooks/DAO/proposal/useSubmitProposal.ts
+++ b/src/hooks/DAO/proposal/useSubmitProposal.ts
@@ -116,8 +116,8 @@ export default function useSubmitProposal() {
         if (azoriusModule && azoriusModule.moduleContract) {
           const azoriusContract = azoriusModule.moduleContract as Azorius;
           const votingContractAddress = (
-            await azoriusContract.getStrategies('0x0000000000000000000000000000000000000001', 1)
-          )[0][0];
+            await azoriusContract.getStrategies('0x0000000000000000000000000000000000000001', 0)
+          )[1];
           const votingContract = BaseStrategy__factory.connect(
             votingContractAddress,
             signerOrProvider
@@ -378,9 +378,9 @@ export default function useSubmitProposal() {
           const votingStrategyAddress = (
             await azoriusModuleContract.getStrategies(
               '0x0000000000000000000000000000000000000001',
-              1
+              0
             )
-          )[0][0];
+          )[1];
           submitAzoriusProposal({
             proposalData,
             pendingToastMessage,

--- a/src/hooks/DAO/proposal/useSubmitProposal.ts
+++ b/src/hooks/DAO/proposal/useSubmitProposal.ts
@@ -115,11 +115,9 @@ export default function useSubmitProposal() {
 
         if (azoriusModule && azoriusModule.moduleContract) {
           const azoriusContract = azoriusModule.moduleContract as Azorius;
-          const votingContractAddress = await azoriusContract
-            .queryFilter(azoriusContract.filters.EnabledStrategy())
-            .then(strategiesEnabled => {
-              return strategiesEnabled[0].args.strategy;
-            });
+          const votingContractAddress = (
+            await azoriusContract.getStrategies('0x0000000000000000000000000000000000000001', 1)
+          )[0][0];
           const votingContract = BaseStrategy__factory.connect(
             votingContractAddress,
             signerOrProvider
@@ -377,11 +375,12 @@ export default function useSubmitProposal() {
           });
         } else {
           const azoriusModuleContract = azoriusModule.moduleContract as Azorius;
-          const votingStrategyAddress = await azoriusModuleContract
-            .queryFilter(azoriusModuleContract.filters.EnabledStrategy())
-            .then(strategiesEnabled => {
-              return strategiesEnabled[0].args.strategy;
-            });
+          const votingStrategyAddress = (
+            await azoriusModuleContract.getStrategies(
+              '0x0000000000000000000000000000000000000001',
+              1
+            )
+          )[0][0];
           submitAzoriusProposal({
             proposalData,
             pendingToastMessage,

--- a/src/hooks/DAO/proposal/useSubmitProposal.ts
+++ b/src/hooks/DAO/proposal/useSubmitProposal.ts
@@ -115,6 +115,7 @@ export default function useSubmitProposal() {
 
         if (azoriusModule && azoriusModule.moduleContract) {
           const azoriusContract = azoriusModule.moduleContract as Azorius;
+          // @dev assumes the first strategy is the voting contract
           const votingContractAddress = (
             await azoriusContract.getStrategies('0x0000000000000000000000000000000000000001', 0)
           )[1];
@@ -375,6 +376,7 @@ export default function useSubmitProposal() {
           });
         } else {
           const azoriusModuleContract = azoriusModule.moduleContract as Azorius;
+          // @dev assumes the first strategy is the voting contract
           const votingStrategyAddress = (
             await azoriusModuleContract.getStrategies(
               '0x0000000000000000000000000000000000000001',

--- a/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
+++ b/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
@@ -58,6 +58,7 @@ export default function useUserERC721VotingTokens(
         const azoriusModule = getAzoriusModuleFromModules(safeModules);
         if (azoriusModule && azoriusModule.moduleContract) {
           const azoriusContract = azoriusModule.moduleContract as Azorius;
+          // @dev assumes the first strategy is the voting contract
           const votingContractAddress = (
             await azoriusContract.getStrategies('0x0000000000000000000000000000000000000001', 0)
           )[1];

--- a/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
+++ b/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
@@ -58,11 +58,9 @@ export default function useUserERC721VotingTokens(
         const azoriusModule = getAzoriusModuleFromModules(safeModules);
         if (azoriusModule && azoriusModule.moduleContract) {
           const azoriusContract = azoriusModule.moduleContract as Azorius;
-          const votingContractAddress = await azoriusContract
-            .queryFilter(azoriusContract.filters.EnabledStrategy())
-            .then(strategiesEnabled => {
-              return strategiesEnabled[0].args.strategy;
-            });
+          const votingContractAddress = (
+            await azoriusContract.getStrategies('0x0000000000000000000000000000000000000001', 1)
+          )[0][0];
           votingContract = LinearERC721Voting__factory.connect(
             votingContractAddress,
             signerOrProvider

--- a/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
+++ b/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
@@ -59,8 +59,8 @@ export default function useUserERC721VotingTokens(
         if (azoriusModule && azoriusModule.moduleContract) {
           const azoriusContract = azoriusModule.moduleContract as Azorius;
           const votingContractAddress = (
-            await azoriusContract.getStrategies('0x0000000000000000000000000000000000000001', 1)
-          )[0][0];
+            await azoriusContract.getStrategies('0x0000000000000000000000000000000000000001', 0)
+          )[1];
           votingContract = LinearERC721Voting__factory.connect(
             votingContractAddress,
             signerOrProvider

--- a/src/hooks/DAO/useDeployAzorius.ts
+++ b/src/hooks/DAO/useDeployAzorius.ts
@@ -116,7 +116,6 @@ const useDeployAzorius = () => {
         successToastMessage: t('proposalCreateSuccessToastMessage', { ns: 'proposal' }),
         failedToastMessage: t('proposalCreateFailureToastMessage', { ns: 'proposal' }),
         successCallback: () => push(DAO_ROUTES.proposals.relative(daoAddress)),
-        safeAddress: daoAddress,
       });
     },
     [

--- a/src/hooks/utils/cache/cacheDefaults.ts
+++ b/src/hooks/utils/cache/cacheDefaults.ts
@@ -29,6 +29,7 @@ export enum CacheKeys {
   DAO_NAME_PREFIX = 'dao_name_',
   DECODED_TRANSACTION_PREFIX = 'decode_trans_',
   MULTISIG_METADATA_PREFIX = 'm_m_',
+  MASTER_COPY_PREFIX = 'master_copy_of_',
 }
 
 interface IndexedObject {

--- a/src/utils/azorius.ts
+++ b/src/utils/azorius.ts
@@ -104,7 +104,7 @@ export const getProposalVotes = async (
       ...rest,
       voter,
       choice: VOTE_CHOICES[voteType],
-    };
+    } as ProposalVote; // This bypasses the type check, but it's fine
   });
 };
 


### PR DESCRIPTION
## Description

This PR strives to remove some of the loading errors from the 429 request error seen in the app. 

First I saw an opportunity to save on the strain of Event filtering by replacing the queryFilter for `EnabledStrategies()` with  just a call on the contract `getStrategies()` to retrieve the voting contract address (as its labeled in the code). 

The second part of the fix is to be considered a bandaid. After discussing with @adamgall There is a better and more efficient pattern for retrieving the master copy instead of relying on the event `queryFilter`. This will be detailed later in a card in `Fractal Maintenance` Project Board. 

For now I'm using the `useLocalStoage` hook that we have in place to store `master_copy_of`. to save `proxyAddress: masterCopyAddress`. So once requested and found we now cache these values so that we don't have to relook up these values don't change.

## Notes
Additional to Adam Suggested fix. I've noticed that current patterns in `useLocalStorage` hasn't scaled well and could use an relook. it works for now so not a priority for V1 at the moment. 


## Issue



## Testing



## Screenshots (if applicable)


