### PR TITLE
Fix Multiple Re-render caused by `useEffect`

### DIFF
--- a/src/components/pages/DaoHierarchy/DaoNode.tsx
+++ b/src/components/pages/DaoHierarchy/DaoNode.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@chakra-ui/react';
 import { utils } from 'ethers';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useLoadDAONode } from '../../../hooks/DAO/loaders/useLoadDAONode';
 import { useLoadDAOData } from '../../../hooks/DAO/useDAOData';
 import { useFractal } from '../../../providers/App/AppProvider';
@@ -26,6 +26,7 @@ export function DaoNode({
   daoAddress?: string;
   depth: number;
 }) {
+  const onMountOnly = useRef(true);
   const [fractalNode, setNode] = useState<FractalNode>();
   const { loadDao } = useLoadDAONode();
   const { daoData } = useLoadDAOData(fractalNode, parentAddress);
@@ -38,7 +39,7 @@ export function DaoNode({
   const isCurrentDAO = daoAddress === currentDAOAddress;
 
   useEffect(() => {
-    if (daoAddress) {
+    if (daoAddress && onMountOnly.current) {
       loadDao(utils.getAddress(daoAddress)).then(_node => {
         const errorNode = _node as WithError;
         if (!errorNode.error) {
@@ -79,6 +80,7 @@ export function DaoNode({
           });
         }
       });
+      onMountOnly.current = false;
     }
   }, [loadDao, daoAddress, fractalNode?.nodeHierarchy.childNodes, depth]);
 


### PR DESCRIPTION
## Description

Fixed continuous re-rendering issue on Hierarchy Page

This patch addresses a performance issue on the Hierarchy Page observed while navigating between DAOs. A persistent error was logged in the console, and the performance monitor in the development tools never stabilized. Additionally, navigating to a new DAO from this page was hindered due to this problem.

The issue was traced back to a `useEffect` hook that was continuously re-executing after component mounting, causing unnecessary re-renders. To resolve this, a `useRef` hook has been added to prevent the `useEffect` from re-executing, thus improving the page's performance and navigation stability.


## Notes
I separated this fix from #1373 so that it can be merged separately, But this should be merged first.


## Issue



## Testing



## Screenshots (if applicable)


