### PR TITLE
Align deployment of Safe to be of same version as Safe UI-deployed and having fallback handler attached

### DIFF
--- a/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
@@ -1,10 +1,11 @@
 import { Box, Button, Text, Flex } from '@chakra-ui/react';
 import { Check } from '@decent-org/fractal-ui';
 import { TypedDataSigner } from '@ethersproject/abstract-signer';
-import { GnosisSafe__factory, MultisigFreezeGuard } from '@fractal-framework/fractal-contracts';
+import { MultisigFreezeGuard } from '@fractal-framework/fractal-contracts';
 import { SafeMultisigTransactionWithTransfersResponse } from '@safe-global/safe-service-client';
 import { Signer } from 'ethers';
 import { useTranslation } from 'react-i18next';
+import { GnosisSafeL2__factory } from '../../../assets/typechain-types/usul/factories/@gnosis.pm/safe-contracts/contracts';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
 import { buildSafeTransaction, buildSignatureBytes, EIP712_SAFE_TX_TYPE } from '../../../helpers';
 import { logError } from '../../../helpers/errorLogging';
@@ -121,7 +122,7 @@ export function TxActions({
       if (!signerOrProvider || !safe?.address || !multisigTx.confirmations) {
         return;
       }
-      const safeContract = GnosisSafe__factory.connect(safe.address, signerOrProvider);
+      const safeContract = GnosisSafeL2__factory.connect(safe.address, signerOrProvider);
       const safeTx = buildSafeTransaction({
         ...multisigTx,
       });

--- a/src/hooks/DAO/proposal/useSubmitProposal.ts
+++ b/src/hooks/DAO/proposal/useSubmitProposal.ts
@@ -1,14 +1,11 @@
 import { TypedDataSigner } from '@ethersproject/abstract-signer';
-import {
-  Azorius,
-  BaseStrategy__factory,
-  GnosisSafe__factory,
-} from '@fractal-framework/fractal-contracts';
+import { Azorius, BaseStrategy__factory } from '@fractal-framework/fractal-contracts';
 import axios from 'axios';
 import { BigNumber, Signer, utils } from 'ethers';
 import { getAddress, isAddress } from 'ethers/lib/utils';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import { toast } from 'react-toastify';
+import { GnosisSafeL2__factory } from '../../../assets/typechain-types/usul/factories/@gnosis.pm/safe-contracts/contracts';
 import { ADDRESS_MULTISIG_METADATA } from '../../../constants/common';
 import { buildSafeAPIPost, encodeMultiSend } from '../../../helpers';
 import { logError } from '../../../helpers/errorLogging';
@@ -241,7 +238,7 @@ export default function useSubmitProposal() {
           operation = 0;
         }
 
-        const safeContract = GnosisSafe__factory.connect(safeAddress, signerOrProvider);
+        const safeContract = GnosisSafeL2__factory.connect(safeAddress, signerOrProvider);
         await axios.post(
           buildSafeApiUrl(safeBaseURL, `/safes/${safeAddress}/multisig-transactions/`),
           await buildSafeAPIPost(

--- a/src/hooks/DAO/useBuildDAOTx.ts
+++ b/src/hooks/DAO/useBuildDAOTx.ts
@@ -16,7 +16,10 @@ import useSignerOrProvider from '../utils/useSignerOrProvider';
 
 const useBuildDAOTx = () => {
   const signerOrProvider = useSignerOrProvider();
-  const { createOptions } = useNetworkConfig();
+  const {
+    createOptions,
+    contracts: { fallbackHandler },
+  } = useNetworkConfig();
 
   const {
     baseContracts: {
@@ -121,6 +124,7 @@ const useBuildDAOTx = () => {
         baseContracts,
         azoriusContracts,
         daoData,
+        fallbackHandler,
         parentAddress,
         parentTokenAddress
       );
@@ -183,6 +187,7 @@ const useBuildDAOTx = () => {
       dao,
       governance,
       createOptions,
+      fallbackHandler,
     ]
   );
 

--- a/src/hooks/DAO/useDeployAzorius.ts
+++ b/src/hooks/DAO/useDeployAzorius.ts
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { DAO_ROUTES } from '../../constants/routes';
 import { TxBuilderFactory } from '../../models/TxBuilderFactory';
 import { useFractal } from '../../providers/App/AppProvider';
+import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import {
   BaseContracts,
   AzoriusContracts,
@@ -18,6 +19,9 @@ import useSubmitProposal from './proposal/useSubmitProposal';
 const useDeployAzorius = () => {
   const signerOrProvider = useSignerOrProvider();
   const { push } = useRouter();
+  const {
+    contracts: { fallbackHandler },
+  } = useNetworkConfig();
   const {
     node: { daoAddress, safe },
     baseContracts: {
@@ -81,6 +85,7 @@ const useDeployAzorius = () => {
         baseContracts,
         azoriusContracts,
         daoData,
+        fallbackHandler,
         undefined,
         undefined
       );
@@ -143,6 +148,7 @@ const useDeployAzorius = () => {
       submitProposal,
       push,
       safe,
+      fallbackHandler,
     ]
   );
 

--- a/src/hooks/safe/useSafeContracts.ts
+++ b/src/hooks/safe/useSafeContracts.ts
@@ -7,7 +7,6 @@ import {
   MultisigFreezeVoting__factory,
   VotesERC20__factory,
   GnosisSafeProxyFactory__factory,
-  GnosisSafe__factory,
   ModuleProxyFactory__factory,
   LinearERC20Voting__factory,
   Azorius__factory,
@@ -19,6 +18,7 @@ import {
 } from '@fractal-framework/fractal-contracts';
 import { useMemo } from 'react';
 import { MultiSend__factory } from '../../assets/typechain-types/usul';
+import { GnosisSafeL2__factory } from '../../assets/typechain-types/usul/factories/@gnosis.pm/safe-contracts/contracts';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { useEthersProvider } from '../utils/useEthersProvider';
 import useSignerOrProvider from '../utils/useSignerOrProvider';
@@ -76,8 +76,8 @@ export default function useSafeContracts() {
     };
 
     const safeSingletonContract = {
-      asSigner: GnosisSafe__factory.connect(safe, signerOrProvider),
-      asProvider: GnosisSafe__factory.connect(safe, provider),
+      asSigner: GnosisSafeL2__factory.connect(safe, signerOrProvider),
+      asProvider: GnosisSafeL2__factory.connect(safe, provider),
     };
 
     const zodiacModuleProxyFactoryContract = {

--- a/src/models/AzoriusTxBuilder.ts
+++ b/src/models/AzoriusTxBuilder.ts
@@ -1,7 +1,6 @@
 import {
   Azorius,
   Azorius__factory,
-  GnosisSafe,
   LinearERC20Voting,
   LinearERC20Voting__factory,
   LinearERC721Voting,
@@ -11,6 +10,7 @@ import {
 } from '@fractal-framework/fractal-contracts';
 import { BigNumber } from 'ethers';
 import { defaultAbiCoder, getCreate2Address, solidityKeccak256 } from 'ethers/lib/utils';
+import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { buildContractCall, getRandomBytes } from '../helpers';
 import {
   BaseContracts,
@@ -25,7 +25,7 @@ import { BaseTxBuilder } from './BaseTxBuilder';
 import { generateContractByteCodeLinear, generateSalt } from './helpers/utils';
 
 export class AzoriusTxBuilder extends BaseTxBuilder {
-  private readonly safeContract: GnosisSafe;
+  private readonly safeContract: GnosisSafeL2;
   private readonly predictedSafeAddress: string;
 
   private encodedSetupTokenData: string | undefined;
@@ -54,7 +54,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
     baseContracts: BaseContracts,
     azoriusContracts: AzoriusContracts,
     daoData: AzoriusERC20DAO | AzoriusERC721DAO,
-    safeContract: GnosisSafe,
+    safeContract: GnosisSafeL2,
     predictedSafeAddress: string,
     parentAddress?: string,
     parentTokenAddress?: string

--- a/src/models/DaoTxBuilder.ts
+++ b/src/models/DaoTxBuilder.ts
@@ -1,5 +1,5 @@
-import { GnosisSafe } from '@fractal-framework/fractal-contracts';
 import { ethers } from 'ethers';
+import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { buildContractCall, encodeMultiSend } from '../helpers';
 import {
   BaseContracts,
@@ -24,7 +24,7 @@ export class DaoTxBuilder extends BaseTxBuilder {
   // Safe Data
   private predictedSafeAddress: string;
   private readonly createSafeTx: SafeTransaction;
-  private readonly safeContract: GnosisSafe;
+  private readonly safeContract: GnosisSafeL2;
   private readonly parentStrategyType?: VotingStrategyType;
   private readonly parentStrategyAddress?: string;
 
@@ -42,7 +42,7 @@ export class DaoTxBuilder extends BaseTxBuilder {
     saltNum: string,
     predictedSafeAddress: string,
     createSafeTx: SafeTransaction,
-    safeContract: GnosisSafe,
+    safeContract: GnosisSafeL2,
     txBuilderFactory: TxBuilderFactory,
     parentAddress?: string,
     parentTokenAddress?: string,

--- a/src/models/FreezeGuardTxBuilder.ts
+++ b/src/models/FreezeGuardTxBuilder.ts
@@ -1,6 +1,5 @@
 import {
   Azorius,
-  GnosisSafe,
   AzoriusFreezeGuard__factory,
   ERC20FreezeVoting__factory,
   MultisigFreezeGuard__factory,
@@ -12,6 +11,7 @@ import {
 } from '@fractal-framework/fractal-contracts';
 import { ethers } from 'ethers';
 import { getCreate2Address, solidityKeccak256 } from 'ethers/lib/utils';
+import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { buildContractCall } from '../helpers';
 import {
   BaseContracts,
@@ -33,7 +33,7 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
   private readonly saltNum;
 
   // Safe Data
-  private readonly safeContract: GnosisSafe;
+  private readonly safeContract: GnosisSafeL2;
 
   // Freeze Voting Data
   private freezeVotingType: any;
@@ -55,7 +55,7 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
     signerOrProvider: any,
     baseContracts: BaseContracts,
     daoData: SubDAO,
-    safeContract: GnosisSafe,
+    safeContract: GnosisSafeL2,
     saltNum: string,
     parentAddress: string,
     parentTokenAddress?: string,
@@ -134,7 +134,7 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
     );
   }
 
-  public buildSetGuardTx(contract: GnosisSafe | Azorius): SafeTransaction {
+  public buildSetGuardTx(contract: GnosisSafeL2 | Azorius): SafeTransaction {
     return buildContractCall(contract, 'setGuard', [this.freezeGuardAddress], 0, false);
   }
 

--- a/src/models/MultisigTxBuilder.ts
+++ b/src/models/MultisigTxBuilder.ts
@@ -1,13 +1,13 @@
-import { GnosisSafe } from '@fractal-framework/fractal-contracts';
+import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { buildContractCall } from '../helpers';
 import { BaseContracts, SafeMultisigDAO, SafeTransaction } from '../types';
 
 export class MultisigTxBuilder {
   private baseContracts: BaseContracts;
   private readonly daoData: SafeMultisigDAO;
-  private readonly safeContract: GnosisSafe;
+  private readonly safeContract: GnosisSafeL2;
 
-  constructor(baseContracts: BaseContracts, daoData: SafeMultisigDAO, safeContract: GnosisSafe) {
+  constructor(baseContracts: BaseContracts, daoData: SafeMultisigDAO, safeContract: GnosisSafeL2) {
     this.baseContracts = baseContracts;
     this.daoData = daoData;
     this.safeContract = safeContract;

--- a/src/models/TxBuilderFactory.ts
+++ b/src/models/TxBuilderFactory.ts
@@ -1,5 +1,6 @@
-import { GnosisSafe, GnosisSafe__factory } from '@fractal-framework/fractal-contracts';
 import { ethers } from 'ethers';
+import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
+import { GnosisSafeL2__factory } from '../assets/typechain-types/usul/factories/@gnosis.pm/safe-contracts/contracts';
 import { getRandomBytes } from '../helpers';
 import {
   BaseContracts,
@@ -24,13 +25,15 @@ export class TxBuilderFactory extends BaseTxBuilder {
   // Safe Data
   public predictedSafeAddress: string | undefined;
   public createSafeTx: SafeTransaction | undefined;
-  private safeContract: GnosisSafe | undefined;
+  private safeContract: GnosisSafeL2 | undefined;
+  public fallbackHandler: string;
 
   constructor(
     signerOrProvider: ethers.Signer | any,
     baseContracts: BaseContracts,
     azoriusContracts: AzoriusContracts | undefined,
     daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO | SubDAO,
+    fallbackHandler: string,
     parentAddress?: string,
     parentTokenAddress?: string
   ) {
@@ -43,11 +46,12 @@ export class TxBuilderFactory extends BaseTxBuilder {
       parentTokenAddress
     );
 
+    this.fallbackHandler = fallbackHandler;
     this.saltNum = getRandomBytes();
   }
 
   public setSafeContract(safeAddress: string) {
-    const safeContract = GnosisSafe__factory.connect(safeAddress, this.signerOrProvider);
+    const safeContract = GnosisSafeL2__factory.connect(safeAddress, this.signerOrProvider);
     this.safeContract = safeContract;
   }
 
@@ -58,6 +62,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
       this.baseContracts.safeSingletonContract,
       this.daoData as SafeMultisigDAO,
       this.saltNum,
+      this.fallbackHandler,
       !!this.azoriusContracts
     );
 

--- a/src/models/helpers/fractalModuleData.ts
+++ b/src/models/helpers/fractalModuleData.ts
@@ -1,10 +1,10 @@
 import {
   FractalModule,
   FractalModule__factory,
-  GnosisSafe,
   ModuleProxyFactory,
 } from '@fractal-framework/fractal-contracts';
 import { ethers } from 'ethers';
+import { GnosisSafeL2 } from '../../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { buildContractCall } from '../../helpers/crypto';
 import { SafeTransaction } from '../../types';
 import {
@@ -23,7 +23,7 @@ export interface FractalModuleData {
 export const fractalModuleData = (
   fractalModuleMasterCopyContract: FractalModule,
   zodiacModuleProxyFactoryContract: ModuleProxyFactory,
-  safeContract: GnosisSafe,
+  safeContract: GnosisSafeL2,
   saltNum: string,
   parentAddress?: string
 ): FractalModuleData => {

--- a/src/models/helpers/safeData.ts
+++ b/src/models/helpers/safeData.ts
@@ -1,7 +1,8 @@
-import { GnosisSafe, GnosisSafeProxyFactory } from '@fractal-framework/fractal-contracts';
+import { GnosisSafeProxyFactory } from '@fractal-framework/fractal-contracts';
 import { ethers } from 'ethers';
 import { getCreate2Address, solidityKeccak256 } from 'ethers/lib/utils';
 import { MultiSend } from '../../assets/typechain-types/usul';
+import { GnosisSafeL2 } from '../../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { buildContractCall } from '../../helpers/crypto';
 import { SafeMultisigDAO } from '../../types';
 const { AddressZero, HashZero } = ethers.constants;
@@ -9,9 +10,10 @@ const { AddressZero, HashZero } = ethers.constants;
 export const safeData = async (
   multiSendContract: MultiSend,
   safeFactoryContract: GnosisSafeProxyFactory,
-  safeSingletonContract: GnosisSafe,
+  safeSingletonContract: GnosisSafeL2,
   daoData: SafeMultisigDAO,
   saltNum: string,
+  fallbackHandler: string,
   hasAzorius?: boolean
 ) => {
   const signers = hasAzorius
@@ -26,7 +28,7 @@ export const safeData = async (
     1, // Threshold
     AddressZero,
     HashZero,
-    AddressZero,
+    fallbackHandler, // Fallback handler
     AddressZero,
     0,
     AddressZero,

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -12,9 +12,10 @@ import MultisigFreezeVoting from '@fractal-framework/fractal-contracts/deploymen
 import VotesERC20 from '@fractal-framework/fractal-contracts/deployments/mainnet/VotesERC20.json';
 import VotesERC20Wrapper from '@fractal-framework/fractal-contracts/deployments/mainnet/VotesERC20Wrapper.json';
 import {
-  getSafeSingletonDeployment,
   getProxyFactoryDeployment,
   getMultiSendCallOnlyDeployment,
+  getSafeL2SingletonDeployment,
+  getCompatibilityFallbackHandlerDeployment,
 } from '@safe-global/safe-deployments';
 import { mainnet } from 'wagmi/chains';
 import { GovernanceType } from '../../../types';
@@ -47,7 +48,11 @@ export const mainnetConfig: NetworkConfig = {
     erc20FreezeVotingMasterCopy: ERC20FreezeVoting.address,
     erc721FreezeVotingMasterCopy: '', // TODO - Add actual address once contract is deployed on mainnet
     multisigFreezeGuardMasterCopy: MultisigFreezeGuard.address,
-    safe: getSafeSingletonDeployment({ version: SAFE_VERSION, network: CHAIN_ID.toString() })
+    fallbackHandler: getCompatibilityFallbackHandlerDeployment({
+      version: SAFE_VERSION,
+      network: CHAIN_ID.toString(),
+    })?.defaultAddress!,
+    safe: getSafeL2SingletonDeployment({ version: SAFE_VERSION, network: CHAIN_ID.toString() })
       ?.defaultAddress!,
     safeFactory: getProxyFactoryDeployment({
       version: SAFE_VERSION,

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -51,19 +51,19 @@ export const mainnetConfig: NetworkConfig = {
     fallbackHandler: getCompatibilityFallbackHandlerDeployment({
       version: SAFE_VERSION,
       network: CHAIN_ID.toString(),
-    })?.defaultAddress!,
+    })?.networkAddresses[CHAIN_ID.toString()]!,
     safe: getSafeL2SingletonDeployment({ version: SAFE_VERSION, network: CHAIN_ID.toString() })
-      ?.defaultAddress!,
+      ?.networkAddresses[CHAIN_ID.toString()]!,
     safeFactory: getProxyFactoryDeployment({
       version: SAFE_VERSION,
       network: CHAIN_ID.toString(),
-    })?.defaultAddress!,
+    })?.networkAddresses[CHAIN_ID.toString()]!,
     zodiacModuleProxyFactory: ModuleProxyFactory.address,
     linearVotingMasterCopy: LinearERC20Voting.address,
     multisend: getMultiSendCallOnlyDeployment({
       version: SAFE_VERSION,
       network: CHAIN_ID.toString(),
-    })?.defaultAddress!,
+    })?.networkAddresses[CHAIN_ID.toString()]!,
     votesERC20WrapperMasterCopy: VotesERC20Wrapper.address,
     keyValuePairs: KeyValuePairs.address,
   },

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -53,17 +53,17 @@ export const polygonConfig: NetworkConfig = {
       network: CHAIN_ID.toString(),
     })?.networkAddresses[CHAIN_ID.toString()]!,
     safe: getSafeL2SingletonDeployment({ version: SAFE_VERSION, network: CHAIN_ID.toString() })
-      ?.defaultAddress!,
+      ?.networkAddresses[CHAIN_ID.toString()]!,
     safeFactory: getProxyFactoryDeployment({
       version: SAFE_VERSION,
       network: CHAIN_ID.toString(),
-    })?.defaultAddress!,
+    })?.networkAddresses[CHAIN_ID.toString()]!,
     zodiacModuleProxyFactory: ModuleProxyFactory.address,
     linearVotingMasterCopy: LinearERC20Voting.address,
     multisend: getMultiSendCallOnlyDeployment({
       version: SAFE_VERSION,
       network: CHAIN_ID.toString(),
-    })?.defaultAddress!,
+    })?.networkAddresses[CHAIN_ID.toString()]!,
     votesERC20WrapperMasterCopy: VotesERC20Wrapper.address,
     keyValuePairs: KeyValuePairs.address,
   },

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -12,9 +12,10 @@ import MultisigFreezeVoting from '@fractal-framework/fractal-contracts/deploymen
 import VotesERC20 from '@fractal-framework/fractal-contracts/deployments/polygon/VotesERC20.json';
 import VotesERC20Wrapper from '@fractal-framework/fractal-contracts/deployments/polygon/VotesERC20Wrapper.json';
 import {
-  getSafeSingletonDeployment,
   getProxyFactoryDeployment,
   getMultiSendCallOnlyDeployment,
+  getSafeL2SingletonDeployment,
+  getCompatibilityFallbackHandlerDeployment,
 } from '@safe-global/safe-deployments';
 import { polygon } from 'wagmi/chains';
 import { GovernanceType } from '../../../types';
@@ -47,7 +48,11 @@ export const polygonConfig: NetworkConfig = {
     erc20FreezeVotingMasterCopy: ERC20FreezeVoting.address,
     erc721FreezeVotingMasterCopy: '',
     multisigFreezeGuardMasterCopy: MultisigFreezeGuard.address,
-    safe: getSafeSingletonDeployment({ version: SAFE_VERSION, network: CHAIN_ID.toString() })
+    fallbackHandler: getCompatibilityFallbackHandlerDeployment({
+      version: SAFE_VERSION,
+      network: CHAIN_ID.toString(),
+    })?.defaultAddress!,
+    safe: getSafeL2SingletonDeployment({ version: SAFE_VERSION, network: CHAIN_ID.toString() })
       ?.defaultAddress!,
     safeFactory: getProxyFactoryDeployment({
       version: SAFE_VERSION,

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -51,7 +51,7 @@ export const polygonConfig: NetworkConfig = {
     fallbackHandler: getCompatibilityFallbackHandlerDeployment({
       version: SAFE_VERSION,
       network: CHAIN_ID.toString(),
-    })?.defaultAddress!,
+    })?.networkAddresses[CHAIN_ID.toString()]!,
     safe: getSafeL2SingletonDeployment({ version: SAFE_VERSION, network: CHAIN_ID.toString() })
       ?.defaultAddress!,
     safeFactory: getProxyFactoryDeployment({

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -16,7 +16,8 @@ import VotesERC20Wrapper from '@fractal-framework/fractal-contracts/deployments/
 import {
   getMultiSendCallOnlyDeployment,
   getProxyFactoryDeployment,
-  getSafeSingletonDeployment,
+  getSafeL2SingletonDeployment,
+  getCompatibilityFallbackHandlerDeployment,
 } from '@safe-global/safe-deployments';
 import { sepolia } from 'wagmi/chains';
 import { GovernanceType } from '../../../types';
@@ -48,7 +49,11 @@ export const sepoliaConfig: NetworkConfig = {
     erc20FreezeVotingMasterCopy: ERC20FreezeVoting.address,
     erc721FreezeVotingMasterCopy: ERC721FreezeVoting.address,
     multisigFreezeGuardMasterCopy: MultisigFreezeGuard.address,
-    safe: getSafeSingletonDeployment({ version: SAFE_VERSION, network: CHAIN_ID.toString() })
+    fallbackHandler: getCompatibilityFallbackHandlerDeployment({
+      version: SAFE_VERSION,
+      network: CHAIN_ID.toString(),
+    })?.defaultAddress!,
+    safe: getSafeL2SingletonDeployment({ version: SAFE_VERSION, network: CHAIN_ID.toString() })
       ?.defaultAddress!,
     safeFactory: getProxyFactoryDeployment({
       version: SAFE_VERSION,

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -52,7 +52,7 @@ export const sepoliaConfig: NetworkConfig = {
     fallbackHandler: getCompatibilityFallbackHandlerDeployment({
       version: SAFE_VERSION,
       network: CHAIN_ID.toString(),
-    })?.defaultAddress!,
+    })?.networkAddresses[CHAIN_ID.toString()]!,
     safe: getSafeL2SingletonDeployment({ version: SAFE_VERSION, network: CHAIN_ID.toString() })
       ?.defaultAddress!,
     safeFactory: getProxyFactoryDeployment({

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -54,17 +54,17 @@ export const sepoliaConfig: NetworkConfig = {
       network: CHAIN_ID.toString(),
     })?.networkAddresses[CHAIN_ID.toString()]!,
     safe: getSafeL2SingletonDeployment({ version: SAFE_VERSION, network: CHAIN_ID.toString() })
-      ?.defaultAddress!,
+      ?.networkAddresses[CHAIN_ID.toString()]!,
     safeFactory: getProxyFactoryDeployment({
       version: SAFE_VERSION,
       network: CHAIN_ID.toString(),
-    })?.defaultAddress!,
+    })?.networkAddresses[CHAIN_ID.toString()]!,
     zodiacModuleProxyFactory: ModuleProxyFactory.address,
     linearVotingMasterCopy: LinearERC20Voting.address,
     multisend: getMultiSendCallOnlyDeployment({
       version: SAFE_VERSION,
       network: CHAIN_ID.toString(),
-    })?.defaultAddress!,
+    })?.networkAddresses[CHAIN_ID.toString()]!,
     votesERC20WrapperMasterCopy: VotesERC20Wrapper.address,
     keyValuePairs: KeyValuePairs.address,
   },

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -1,6 +1,5 @@
 import {
   GnosisSafeProxyFactory,
-  GnosisSafe,
   ModuleProxyFactory,
   Azorius,
   LinearERC20Voting,
@@ -16,6 +15,7 @@ import {
   ERC721FreezeVoting,
 } from '@fractal-framework/fractal-contracts';
 import { MultiSend } from '../assets/typechain-types/usul';
+import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 
 export interface ContractEvent {
   blockTimestamp: number;
@@ -31,7 +31,7 @@ export interface DAOContracts {
   safeFactoryContract: ContractConnection<GnosisSafeProxyFactory>;
   fractalAzoriusMasterCopyContract: ContractConnection<Azorius>;
   linearVotingMasterCopyContract: ContractConnection<LinearERC20Voting>;
-  safeSingletonContract: ContractConnection<GnosisSafe>;
+  safeSingletonContract: ContractConnection<GnosisSafeL2>;
   zodiacModuleProxyFactoryContract: ContractConnection<ModuleProxyFactory>;
   fractalModuleMasterCopyContract: ContractConnection<FractalModule>;
   fractalRegistryContract: ContractConnection<FractalRegistry>;
@@ -48,7 +48,7 @@ export interface BaseContracts {
   fractalModuleMasterCopyContract: FractalModule;
   fractalRegistryContract: FractalRegistry;
   safeFactoryContract: GnosisSafeProxyFactory;
-  safeSingletonContract: GnosisSafe;
+  safeSingletonContract: GnosisSafeL2;
   multisigFreezeGuardMasterCopyContract: MultisigFreezeGuard;
   multiSendContract: MultiSend;
   freezeERC20VotingMasterCopyContract: ERC20FreezeVoting;

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -1,7 +1,6 @@
 import {
   FractalModule,
   FractalRegistry,
-  GnosisSafe,
   GnosisSafeProxyFactory,
   ModuleProxyFactory,
   LinearERC20Voting,
@@ -28,6 +27,7 @@ import { BigNumber } from 'ethers';
 import { Dispatch } from 'react';
 import { LockRelease } from '../assets/typechain-types/dcnt';
 import { MultiSend } from '../assets/typechain-types/usul';
+import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { FractalGovernanceActions } from '../providers/App/governance/action';
 import { GovernanceContractActions } from '../providers/App/governanceContracts/action';
 import { FractalGuardActions } from '../providers/App/guard/action';
@@ -334,7 +334,7 @@ export interface FractalContracts {
   fractalAzoriusMasterCopyContract: ContractConnection<Azorius>;
   linearVotingMasterCopyContract: ContractConnection<LinearERC20Voting>;
   linearVotingERC721MasterCopyContract: ContractConnection<LinearERC721Voting>;
-  safeSingletonContract: ContractConnection<GnosisSafe>;
+  safeSingletonContract: ContractConnection<GnosisSafeL2>;
   zodiacModuleProxyFactoryContract: ContractConnection<ModuleProxyFactory>;
   fractalModuleMasterCopyContract: ContractConnection<FractalModule>;
   fractalRegistryContract: ContractConnection<FractalRegistry>;

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -21,6 +21,7 @@ export type NetworkConfig = {
   contracts: {
     safe: string;
     safeFactory: string;
+    fallbackHandler: string;
     zodiacModuleProxyFactory: string;
     linearVotingMasterCopy: string;
     multisend: string;


### PR DESCRIPTION
## Description
This PR swaps all the `GnosisSafe` usages to `GnosisSafeL2` and adds `fallbackHandler` to the create Safe flow, right into `setup` function call.


## Notes



## Issue

Closes #1361 

## Testing
1. Deploy brand new Safe via Fractal
2. Create new Safe via Safe UI, go to Safe's Settings page
3. Go to Safe UI and find Fractal-created Safe, go to Safe's Settings page
4. Compare Safe created via Fractal and Safe created via Safe UI - their version should be exactly the same (`1.3.0+L2`) and attached Fallback Handler (could be found under "Modules" tab) also should be exactly the same. See screenshots below for references on how it should look like


## Screenshots (if applicable)
<img width="1406" alt="Знімок екрана 2024-02-26 о 19 06 43" src="https://github.com/decent-dao/fractal-interface/assets/25801162/1f65c328-db2a-4e08-ab1e-a3d929f9781d">
<img width="1406" alt="Знімок екрана 2024-02-26 о 19 43 23" src="https://github.com/decent-dao/fractal-interface/assets/25801162/5d8e981c-6180-4ad1-9fa7-fc2532be32b4">


