### PR TITLE
Include a "MAINNET" identifier in the mainnet Alchemy env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
-NEXT_PUBLIC_ALCHEMY_API_KEY=""
+# Alchemy provider API key, used on Mainnet
+NEXT_PUBLIC_ALCHEMY_MAINNET_API_KEY=""
 NEXT_PUBLIC_ALCHEMY_SEPOLIA_API_KEY=""
 # automated testing workflows
 NEXT_PUBLIC_ALCHEMY_TESTING_API_KEY=""

--- a/src/providers/NetworkConfig/rainbow-kit.config.ts
+++ b/src/providers/NetworkConfig/rainbow-kit.config.ts
@@ -27,8 +27,8 @@ export const { chains, publicClient } = configureChains(supportedWagmiChains, [
       const publicNodeNetworkUrl = `ethereum-${chain.name}.publicnode.com`;
       if (chain.id === mainnet.id) {
         return {
-          http: `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
-          webSocket: `wss://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
+          http: `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_MAINNET_API_KEY}`,
+          webSocket: `wss://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_MAINNET_API_KEY}`,
         };
       } else if (chain.id === sepolia.id) {
         return {


### PR DESCRIPTION
To bring some consistency to the environment variable names.

I've already _added_ the new environment variable in Netlify, so this should work in the preview deployments and once merged.

After this code merges into `develop`, it'll be safe to delete `NEXT_PUBLIC_ALCHEMY_API_KEY` from the dev site in Netlify.
After this code merges into `main`, it'll be safe to delete `NEXT_PUBLIC_ALCHEMY_API_KEY` from the prod site in Netlify.

As a side note, I strongly encourage all engineers on the project (@Da-Colon, @mudrila) to set up their own free-tier accounts on Etherscan, Alchemy, Infura, and WalletConnect Cloud, and use those keys in their `.env.local` files.