### PR TITLE
Fix Nested Anchor Tags

### DIFF
--- a/src/components/Proposals/ProposalActions/ProposalAction.tsx
+++ b/src/components/Proposals/ProposalActions/ProposalAction.tsx
@@ -1,9 +1,7 @@
 import { Button, Flex, Text } from '@chakra-ui/react';
-import Link from 'next/link';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
-import { DAO_ROUTES } from '../../../constants/routes';
 import useSnapshotProposal from '../../../hooks/DAO/loaders/snapshot/useSnapshotProposal';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { ExtendedSnapshotProposal, FractalProposal, FractalProposalState } from '../../../types';
@@ -52,7 +50,6 @@ export function ProposalAction({
   onCastSnapshotVote?: () => Promise<void>;
 }) {
   const {
-    node: { daoAddress },
     readOnly: { user, dao },
   } = useFractal();
   const { t } = useTranslation();
@@ -102,15 +99,7 @@ export function ProposalAction({
 
   if (!showActionButton) {
     if (!expandedView) {
-      return (
-        <Button
-          as={Link}
-          href={DAO_ROUTES.proposal.relative(daoAddress, proposal.proposalId)}
-          variant="secondary"
-        >
-          {t('details')}
-        </Button>
-      );
+      return <Button variant="secondary">{t('details')}</Button>;
     }
     // This means that Proposal in state where there's no action to perform
     return null;
@@ -139,17 +128,5 @@ export function ProposalAction({
     );
   }
 
-  return (
-    <Link
-      href={DAO_ROUTES.proposal.relative(daoAddress, proposal.proposalId)}
-      passHref
-    >
-      <Button
-        as="a"
-        variant={showActionButton && canVote ? 'primary' : 'secondary'}
-      >
-        {label}
-      </Button>
-    </Link>
-  );
+  return <Button variant={showActionButton && canVote ? 'primary' : 'secondary'}>{label}</Button>;
 }


### PR DESCRIPTION
Closes #1396 

The `ProposalAction` buttons, which show up in proposal list cards, no longer needs to be a link.

Testing:

On dev load up any DAO that has proposals. Notice that when the proposal list populates, there's an error in the console talking about how nested anchor tags are not allowed.

Then do the same on this branch, and notice how that error does not appear.

@mudrila I would love your eyes on this, specifically. There are three files where the `ProposalAction` component is instantiated:
- src/components/Activity/ActivityGovernance.tsx
- src/components/Proposals/AzoriusDetails/index.tsx
- src/components/Proposals/SnapshotProposalDetails/index.tsx

The first file, `ActivityGovernance.tsx` is the proposal card that shows up on the DAO Home and Proposals pages. That seems good.

But I'm not sure about these other two files. It seems like `AzoriusDetails` and `SnapshotProposalDetails` are both the actual details pages for the various types of proposals. The `ProposalAction` button, in these pages, is being used to display the various "Vote" buttons, when those are relevant? So I probably don't want to just straight up disable their links, as I'm doing in this PR?

I'm thinking that's the case, just want to get your take on it.