### PR TITLE
[BUGFIX] Stale WalletConnect Session

### DIFF
--- a/src/components/ui/menus/AccountDisplay/MenuItems.tsx
+++ b/src/components/ui/menus/AccountDisplay/MenuItems.tsx
@@ -2,17 +2,14 @@ import { MenuList } from '@chakra-ui/react';
 import { Connect, Disconnect } from '@decent-org/fractal-ui';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
 import { useTranslation } from 'react-i18next';
-import { useDisconnect } from 'wagmi';
-import { useFractal } from '../../../../providers/App/AppProvider';
+import { useDisconnect, useWalletClient } from 'wagmi';
 import { MenuItemButton } from './MenuItemButton';
 import { MenuItemNetwork } from './MenuItemNetwork';
 import { MenuItemWallet } from './MenuItemWallet';
 
 export function MenuItems() {
-  const {
-    readOnly: { user },
-  } = useFractal();
   const { disconnect } = useDisconnect();
+  const { data: isConnected } = useWalletClient();
   const { openConnectModal } = useConnectModal();
   const { t } = useTranslation('menu');
   return (
@@ -33,9 +30,9 @@ export function MenuItems() {
         },
       }}
     >
-      {user.address && <MenuItemWallet />}
+      {isConnected && <MenuItemWallet />}
       <MenuItemNetwork />
-      {!user.address && (
+      {!isConnected && (
         <MenuItemButton
           testId="accountMenu-connect"
           label={t('connect')}
@@ -43,15 +40,12 @@ export function MenuItems() {
           onClick={openConnectModal}
         />
       )}
-      {user.address && (
+      {isConnected && (
         <MenuItemButton
           testId="accountMenu-disconnect"
           label={t('disconnect')}
           Icon={Disconnect}
-          onClick={() => {
-            disconnect();
-            setTimeout(() => {}, 500);
-          }}
+          onClick={disconnect}
         />
       )}
     </MenuList>

--- a/src/components/ui/menus/AccountDisplay/MenuItems.tsx
+++ b/src/components/ui/menus/AccountDisplay/MenuItems.tsx
@@ -48,7 +48,10 @@ export function MenuItems() {
           testId="accountMenu-disconnect"
           label={t('disconnect')}
           Icon={Disconnect}
-          onClick={disconnect}
+          onClick={() => {
+            disconnect();
+            setTimeout(() => {}, 500);
+          }}
         />
       )}
     </MenuList>


### PR DESCRIPTION
## Description
Looking into MPCVault Wallet Connections, I noticed than after disconnecting from Wallets connected via WalletConnect. I am unable to reopen the wallet connect menu and the Console shows errors related to the session key not matching and then showing `core/relayer` errors. 

After looking at the setup. It appears that what is happening is that for some reason after clicking `disconnect` that the menu closes and causes the func to end before updating local storage that the session has ended. This causes WAGMI and Walletconnect to desync. 

~Adding a small delay (`setTimeout`) after execution of disconnect fixes this issue.~

Instead of using AppState to determine connection status, as this seems to be updated quicker than wagmi's state. switching out to use `useWalletClient` to determine connection status seems to be a better fix.

## Testing
First see the error on dev:
- Connect any wallet via WalletConnect and disconnect.
- Reopen Connect Modal and Select Wallet Connect again. Should do nothing.

On deploy preview do the same thing and you should notice that you are able to click into the WalletConnect QR code again. (You may need to refresh browser after testing the error)
