### PR TITLE
Bug/#1402 proposal time

### DIFF
--- a/src/components/ui/proposal/ProposalCountdown.tsx
+++ b/src/components/ui/proposal/ProposalCountdown.tsx
@@ -64,6 +64,11 @@ export function ProposalCountdown({
   const hoursLeft = Math.floor((secondsLeft! / (60 * 60)) % 24);
   const minutesLeft = Math.floor((secondsLeft! / 60) % 60);
 
+  const showDays = daysLeft > 0;
+  const showHours = showDays || hoursLeft > 0;
+  const showMinutes = showHours || minutesLeft > 0;
+  const showSeconds = secondsLeft >= 0;
+
   return (
     <Tooltip
       label={tooltipLabel}
@@ -82,10 +87,10 @@ export function ProposalCountdown({
             color="chocolate.200"
             textStyle="text-base-mono-semibold"
           >
-            {daysLeft > 0 && `${zeroPad(daysLeft)}:`}
-            {hoursLeft > 0 && `${zeroPad(hoursLeft)}:`}
-            {minutesLeft > 0 && `${zeroPad(minutesLeft)}:`}
-            {secondsLeft! >= 0 && `${zeroPad(secondsLeft! % 60)}`}
+            {showDays && `${zeroPad(daysLeft)}:`}
+            {showHours && `${zeroPad(hoursLeft)}:`}
+            {showMinutes && `${zeroPad(minutesLeft)}:`}
+            {showSeconds && `${zeroPad(secondsLeft % 60)}`}
           </Text>
         </Flex>
       </Flex>

--- a/src/components/ui/proposal/ProposalCountdown.tsx
+++ b/src/components/ui/proposal/ProposalCountdown.tsx
@@ -31,16 +31,13 @@ export function ProposalCountdown({
   const state: FractalProposalState | null = useMemo(() => proposal.state, [proposal]);
 
   const { isSnapshotProposal } = useSnapshotProposal(proposal);
-  const showCountdown = useMemo(
-    () =>
-      !!secondsLeft &&
-      secondsLeft > 0 &&
-      (state === FractalProposalState.ACTIVE ||
-        state === FractalProposalState.TIMELOCKED ||
-        state === FractalProposalState.EXECUTABLE ||
-        isSnapshotProposal),
-    [state, secondsLeft, isSnapshotProposal],
-  );
+  const showCountdown =
+    !!secondsLeft &&
+    secondsLeft > 0 &&
+    (state === FractalProposalState.ACTIVE ||
+      state === FractalProposalState.TIMELOCKED ||
+      state === FractalProposalState.EXECUTABLE ||
+      isSnapshotProposal);
 
   if (!showCountdown) return null;
 


### PR DESCRIPTION
Closes #1402 

As assumed in the issue, we were hiding time "segments" (days, hours, minutes), if they were 0, regardless of whether or not there were "larger" segments that were non-zero.

The code here now forces "zero" segments to display if there is a larger time segment that is still non-zero.

This code was extensively manually tested (by forcing "remaining times" to be specific numbers, via manipulating the code), but it'll be hard to test in realtime given the nature of the issue.