### PR TITLE
Don't log or show Pricing API communication errors in development

### DIFF
--- a/src/providers/App/hooks/usePriceAPI.ts
+++ b/src/providers/App/hooks/usePriceAPI.ts
@@ -41,6 +41,9 @@ export default function usePriceAPI() {
           }
         }
       } catch (e) {
+        // When doing local development, it's unlikely that the Pricing Service is going to be running locally,
+        // so don't worry about logging or showing the error toast.
+        if (process.env.NODE_ENV === 'development') return;
         logError('Error while getting tokens prices', e);
         toast.warning(t('tokenPriceFetchingError'));
         return;


### PR DESCRIPTION
Closes #1434 

This won't be testable on the deploy-preview site. Pretty much just for devs.