### PR TITLE
Feedback/#1404 timezones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "axios": "^0.27.2",
         "classnames": "^2.3.1",
         "date-fns": "^2.29.3",
+        "date-fns-tz": "^2.0.1",
         "ethers": "^5.7.2",
         "evm-proxy-detection": "^1.1.0",
         "formik": "^2.2.9",
@@ -14710,6 +14711,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.1.tgz",
+      "integrity": "sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==",
+      "peerDependencies": {
+        "date-fns": "2.x"
       }
     },
     "node_modules/dayjs": {
@@ -39525,6 +39534,12 @@
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
       "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+    },
+    "date-fns-tz": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.1.tgz",
+      "integrity": "sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==",
+      "requires": {}
     },
     "dayjs": {
       "version": "1.11.7",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "axios": "^0.27.2",
     "classnames": "^2.3.1",
     "date-fns": "^2.29.3",
+    "date-fns-tz": "^2.0.1",
     "ethers": "^5.7.2",
     "evm-proxy-detection": "^1.1.0",
     "formik": "^2.2.9",

--- a/src/components/Proposals/MultisigProposalDetails/TxDetails.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxDetails.tsx
@@ -73,7 +73,8 @@ export function TxDetails({ proposal }: { proposal: MultisigProposal }) {
         />
         <InfoRow
           property={t('created')}
-          value={format(new Date(proposal.eventDate), DEFAULT_DATE_TIME_FORMAT)}
+          value={format(proposal.eventDate, DEFAULT_DATE_TIME_FORMAT)}
+          tooltip={formatInTimeZone(proposal.eventDate, 'GMT', DEFAULT_DATE_TIME_FORMAT)}
         />
         <InfoRow
           property={t('transactionHash')}

--- a/src/components/Proposals/MultisigProposalDetails/TxDetails.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxDetails.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Flex, Text, Tooltip } from '@chakra-ui/react';
+import { Box, Divider, Text } from '@chakra-ui/react';
 import { format } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import { useTranslation } from 'react-i18next';
@@ -7,50 +7,7 @@ import { createAccountSubstring } from '../../../hooks/utils/useDisplayName';
 import { MultisigProposal } from '../../../types';
 import { DEFAULT_DATE_TIME_FORMAT } from '../../../utils/numberFormats';
 import ContentBox from '../../ui/containers/ContentBox';
-import DisplayTransaction from '../../ui/links/DisplayTransaction';
-
-function TransactionOrText({ txHash, value }: { txHash?: string | null; value?: string }) {
-  return txHash ? <DisplayTransaction txHash={txHash} /> : <Text>{value}</Text>;
-}
-
-export function InfoRow({
-  property,
-  value,
-  txHash,
-  tooltip,
-}: {
-  property: string;
-  value?: string;
-  txHash?: string | null;
-  tooltip?: string;
-}) {
-  return (
-    <Flex
-      marginTop={4}
-      justifyContent="space-between"
-    >
-      <Text
-        textStyle="text-base-sans-regular"
-        color="chocolate.200"
-      >
-        {property}
-      </Text>
-      {tooltip === undefined ? (
-        <TransactionOrText
-          txHash={txHash}
-          value={value}
-        />
-      ) : (
-        <Tooltip label={tooltip}>
-          <TransactionOrText
-            txHash={txHash}
-            value={value}
-          />
-        </Tooltip>
-      )}
-    </Flex>
-  );
-}
+import InfoRow from '../../ui/proposal/InfoRow';
 
 export function TxDetails({ proposal }: { proposal: MultisigProposal }) {
   const { t } = useTranslation('proposal');

--- a/src/components/Proposals/MultisigProposalDetails/TxDetails.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxDetails.tsx
@@ -1,5 +1,6 @@
-import { Box, Divider, Flex, Text } from '@chakra-ui/react';
+import { Box, Divider, Flex, Text, Tooltip } from '@chakra-ui/react';
 import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { useTranslation } from 'react-i18next';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
 import { createAccountSubstring } from '../../../hooks/utils/useDisplayName';
@@ -8,14 +9,20 @@ import { DEFAULT_DATE_TIME_FORMAT } from '../../../utils/numberFormats';
 import ContentBox from '../../ui/containers/ContentBox';
 import DisplayTransaction from '../../ui/links/DisplayTransaction';
 
+function TransactionOrText({ txHash, value }: { txHash?: string | null; value?: string }) {
+  return txHash ? <DisplayTransaction txHash={txHash} /> : <Text>{value}</Text>;
+}
+
 export function InfoRow({
   property,
   value,
   txHash,
+  tooltip,
 }: {
   property: string;
   value?: string;
   txHash?: string | null;
+  tooltip?: string;
 }) {
   return (
     <Flex
@@ -28,7 +35,19 @@ export function InfoRow({
       >
         {property}
       </Text>
-      {txHash ? <DisplayTransaction txHash={txHash} /> : <Text>{value}</Text>}
+      {tooltip === undefined ? (
+        <TransactionOrText
+          txHash={txHash}
+          value={value}
+        />
+      ) : (
+        <Tooltip label={tooltip}>
+          <TransactionOrText
+            txHash={txHash}
+            value={value}
+          />
+        </Tooltip>
+      )}
     </Flex>
   );
 }

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -1,6 +1,7 @@
 import { Text, Box, Button, Divider, Flex, Tooltip } from '@chakra-ui/react';
 import { ArrowAngleUp } from '@decent-org/fractal-ui';
 import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { BigNumber } from 'ethers';
 import { useMemo, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -136,10 +137,12 @@ export default function ProposalSummary({
         <InfoRow
           property={t('proposalSummaryStartDate')}
           value={format(startBlockTimeStamp * 1000, DEFAULT_DATE_TIME_FORMAT)}
+          tooltip={formatInTimeZone(startBlockTimeStamp * 1000, 'GMT', DEFAULT_DATE_TIME_FORMAT)}
         />
         <InfoRow
           property={t('proposalSummaryEndDate')}
           value={format(deadlineMs, DEFAULT_DATE_TIME_FORMAT)}
+          tooltip={formatInTimeZone(deadlineMs, 'GMT', DEFAULT_DATE_TIME_FORMAT)}
         />
         <Flex
           marginTop={4}

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -15,8 +15,8 @@ import { DisplayAddress } from '../ui/links/DisplayAddress';
 import DisplayTransaction from '../ui/links/DisplayTransaction';
 import EtherscanLinkBlock from '../ui/links/EtherscanLinkBlock';
 import { InfoBoxLoader } from '../ui/loaders/InfoBoxLoader';
+import InfoRow from '../ui/proposal/InfoRow';
 import { QuorumProgressBar } from '../ui/utils/ProgressBar';
-import { InfoRow } from './MultisigProposalDetails/TxDetails';
 
 export default function ProposalSummary({
   proposal: {

--- a/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalSummary.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalSummary.tsx
@@ -1,5 +1,6 @@
 import { Text, Box, Button, Divider, Flex, Tooltip } from '@chakra-ui/react';
 import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
@@ -88,10 +89,12 @@ export default function SnapshotProposalSummary({ proposal }: ISnapshotProposalS
         <InfoRow
           property={t('proposalSummaryStartDate')}
           value={format(proposal.startTime * 1000, DEFAULT_DATE_TIME_FORMAT)}
+          tooltip={formatInTimeZone(proposal.startTime * 1000, 'GMT', DEFAULT_DATE_TIME_FORMAT)}
         />
         <InfoRow
           property={t('proposalSummaryEndDate')}
           value={format(proposal.endTime * 1000, DEFAULT_DATE_TIME_FORMAT)}
+          tooltip={formatInTimeZone(proposal.endTime * 1000, 'GMT', DEFAULT_DATE_TIME_FORMAT)}
         />
         <Flex
           marginTop={4}

--- a/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalSummary.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalSummary.tsx
@@ -9,8 +9,8 @@ import { DEFAULT_DATE_TIME_FORMAT } from '../../../utils/numberFormats';
 import ContentBox from '../../ui/containers/ContentBox';
 import ExternalLink from '../../ui/links/ExternalLink';
 import { InfoBoxLoader } from '../../ui/loaders/InfoBoxLoader';
+import InfoRow from '../../ui/proposal/InfoRow';
 import { QuorumProgressBar } from '../../ui/utils/ProgressBar';
-import { InfoRow } from '../MultisigProposalDetails/TxDetails';
 import useSnapshotUserVotingWeight from './hooks/useSnapshotUserVotingWeight';
 import useTotalVotes from './hooks/useTotalVotes';
 

--- a/src/components/ui/proposal/InfoRow.tsx
+++ b/src/components/ui/proposal/InfoRow.tsx
@@ -1,10 +1,6 @@
 import { Flex, Text, Tooltip } from '@chakra-ui/react';
 import DisplayTransaction from '../../ui/links/DisplayTransaction';
 
-function TransactionOrText({ txHash, value }: { txHash?: string | null; value?: string }) {
-  return txHash ? <DisplayTransaction txHash={txHash} /> : <Text>{value}</Text>;
-}
-
 export default function InfoRow({
   property,
   value,
@@ -28,16 +24,14 @@ export default function InfoRow({
         {property}
       </Text>
       {tooltip === undefined ? (
-        <TransactionOrText
-          txHash={txHash}
-          value={value}
-        />
+        txHash ? (
+          <DisplayTransaction txHash={txHash} />
+        ) : (
+          <Text>{value}</Text>
+        )
       ) : (
         <Tooltip label={tooltip}>
-          <TransactionOrText
-            txHash={txHash}
-            value={value}
-          />
+          {txHash ? <DisplayTransaction txHash={txHash} /> : <Text>{value}</Text>}
         </Tooltip>
       )}
     </Flex>

--- a/src/components/ui/proposal/InfoRow.tsx
+++ b/src/components/ui/proposal/InfoRow.tsx
@@ -1,0 +1,45 @@
+import { Flex, Text, Tooltip } from '@chakra-ui/react';
+import DisplayTransaction from '../../ui/links/DisplayTransaction';
+
+function TransactionOrText({ txHash, value }: { txHash?: string | null; value?: string }) {
+  return txHash ? <DisplayTransaction txHash={txHash} /> : <Text>{value}</Text>;
+}
+
+export default function InfoRow({
+  property,
+  value,
+  txHash,
+  tooltip,
+}: {
+  property: string;
+  value?: string;
+  txHash?: string | null;
+  tooltip?: string;
+}) {
+  return (
+    <Flex
+      marginTop={4}
+      justifyContent="space-between"
+    >
+      <Text
+        textStyle="text-base-sans-regular"
+        color="chocolate.200"
+      >
+        {property}
+      </Text>
+      {tooltip === undefined ? (
+        <TransactionOrText
+          txHash={txHash}
+          value={value}
+        />
+      ) : (
+        <Tooltip label={tooltip}>
+          <TransactionOrText
+            txHash={txHash}
+            value={value}
+          />
+        </Tooltip>
+      )}
+    </Flex>
+  );
+}

--- a/src/utils/numberFormats.ts
+++ b/src/utils/numberFormats.ts
@@ -2,7 +2,7 @@ import { SafeBalanceUsdResponse } from '@safe-global/safe-service-client';
 import { BigNumber, ethers } from 'ethers';
 import bigDecimal from 'js-big-decimal';
 
-export const DEFAULT_DATE_TIME_FORMAT = 'MMM dd, yyyy, h:mm aa';
+export const DEFAULT_DATE_TIME_FORMAT = 'MMM dd, yyyy, h:mm aa O';
 export const DEFAULT_DATE_FORMAT = 'yyyy-MM-dd';
 
 export const formatPercentage = (


### PR DESCRIPTION
Closes #1404 

### Changes

- Adds user's localized timezone (in the form of GMT offset) to Start and End dates of proposals
  - Works on Azorius, Multisig, and Snapshot proposals
  - <img width="399" alt="Screenshot 2024-03-12 at 3 31 10 PM" src="https://github.com/decent-dao/fractal-interface/assets/706929/53ed9bea-9443-4176-8e94-d873a4f2a4a3">
- Adds tooltip displaying the associated GMT time, which will match what's on Etherscan
  - Works on Azorius, Multisig, and Snapshot proposals
  - <img width="386" alt="Screenshot 2024-03-12 at 3 32 05 PM" src="https://github.com/decent-dao/fractal-interface/assets/706929/e621fcb0-40df-45ef-b356-423025f388f4">
  - In the above screenshot the tooltip happens to cover the End Date, fyi.